### PR TITLE
perf(image): trim iGPU image (drop leftover wheel, purge build tools) [needs Jetson validation]

### DIFF
--- a/Dockerfile.igpu
+++ b/Dockerfile.igpu
@@ -24,8 +24,15 @@ RUN apt-get update && apt-get install -y \
     && curl -fLo "${TORCH_WHEEL}" "https://developer.download.nvidia.com/compute/redist/jp/v61/pytorch/${TORCH_WHEEL}" \
     && echo "${TORCH_WHEEL_SHA256}  ${TORCH_WHEEL}" | sha256sum -c - \
     && pip install --no-cache-dir "./${TORCH_WHEEL}" \
-    && pip install --upgrade pip setuptools wheel "numpy<2" packaging \
-    && apt-get clean && rm -rf /var/lib/apt/lists/*
+    # The downloaded wheel is only needed for the install above; drop it so it
+    # doesn't linger (a few hundred MB) in the final image layer.
+    && rm -f "./${TORCH_WHEEL}" \
+    && pip install --no-cache-dir --upgrade pip setuptools wheel "numpy<2" packaging \
+    # curl/gnupg2/git are build-only (repo key + wheel download + submodule
+    # init already done above); ffmpeg, python3-venv/pip and the runtime CUDA
+    # libs (libopenblas, libcusparselt0) stay for run.sh's first-run setup.
+    && apt-get purge -y curl gnupg2 git && apt-get autoremove -y \
+    && apt-get clean && rm -rf /var/lib/apt/lists/* /root/.cache/pip
 
 WORKDIR /
 COPY ./run.sh ./


### PR DESCRIPTION
## What
Trim the **iGPU (Jetson)** image with safe, same-base cleanups.

Unlike the dGPU image, `Dockerfile.igpu` is single-stage on `l4t-jetpack:r36.4.0` with the **system** Jetson torch wheel (no venv; links JetPack's system CUDA). `run.sh` defers venv/requirements/torch2trt to first-run `script/setup` and reuses the system torch/tensorrt via `--system_site_packages` (`NVIDIA_EMBEDDED=true`). So the dGPU venv-relocation multi-stage does **not** apply here.

What does help, without touching the system torch/tensorrt link surface:
- **Remove the downloaded torch wheel** (a few hundred MB) after `pip install` — it was left in `/usr/src/...` and shipped in the image.
- `--no-cache-dir` on the second pip call + drop `/root/.cache/pip`.
- Purge build-only apt tools (`curl`, `gnupg2`, `git`) after use. `ffmpeg`, `python3-venv`/`pip` and the runtime CUDA libs (`libopenblas`, `libcusparselt0`) stay for first-run setup.

Deliberately conservative: the `-dev` packages (`libcusparselt-dev`, `libopenblas-dev`) are left as-is — dropping them to runtime `-0` variants is a further win but touches what the Jetson torch links, so it's deferred to on-device testing.

## ⚠️ Draft — needs Jetson hardware validation
iGPU never builds in PR CI (build-check is amd64; iGPU only builds via QEMU-arm64 at **release**), and there's no Jetson here.

### On-device checklist before un-drafting
- [ ] Build for arm64 (`docker buildx build --platform linux/arm64 -f Dockerfile.igpu .`)
- [ ] Server starts on the Jetson: first-run `script/setup` builds `.venv`, `import torch` + `import torch2trt` succeed, whisper model + TRT engine build, "listening on :10300"
- [ ] Confirm removing the wheel + build tools didn't break first-run setup (torch2trt `setup.py install` needs no git/curl)
- [ ] Compare pull size vs the current iGPU image (crictl/ctr compressed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)