### PR TITLE
perf(image): trim iGPU image (drop leftover wheel, purge build tools)…

### DIFF
--- a/Dockerfile.igpu
+++ b/Dockerfile.igpu
@@ -24,8 +24,15 @@ RUN apt-get update && apt-get install -y \
     && curl -fLo "${TORCH_WHEEL}" "https://developer.download.nvidia.com/compute/redist/jp/v61/pytorch/${TORCH_WHEEL}" \
     && echo "${TORCH_WHEEL_SHA256}  ${TORCH_WHEEL}" | sha256sum -c - \
     && pip install --no-cache-dir "./${TORCH_WHEEL}" \
-    && pip install --upgrade pip setuptools wheel "numpy<2" packaging \
-    && apt-get clean && rm -rf /var/lib/apt/lists/*
+    # The downloaded wheel is only needed for the install above; drop it so it
+    # doesn't linger (a few hundred MB) in the final image layer.
+    && rm -f "./${TORCH_WHEEL}" \
+    && pip install --no-cache-dir --upgrade pip setuptools wheel "numpy<2" packaging \
+    # curl/gnupg2/git are build-only (repo key + wheel download + submodule
+    # init already done above); ffmpeg, python3-venv/pip and the runtime CUDA
+    # libs (libopenblas, libcusparselt0) stay for run.sh's first-run setup.
+    && apt-get purge -y curl gnupg2 git && apt-get autoremove -y \
+    && apt-get clean && rm -rf /var/lib/apt/lists/* /root/.cache/pip
 
 WORKDIR /
 COPY ./run.sh ./


### PR DESCRIPTION
… (#1005)

The Jetson iGPU build is single-stage on l4t-jetpack with the system torch wheel (no venv, links JetPack's system CUDA), so the dGPU venv-relocation multi-stage does not apply. But there are safe same-base wins:

- Remove the downloaded torch wheel (a few hundred MB) after pip installs it — it was left in /usr/src and shipped in the image.
- --no-cache-dir on the second pip call + drop /root/.cache/pip.
- Purge build-only apt tools (curl, gnupg2, git) after use. ffmpeg, python3-venv/pip and the runtime CUDA libs stay for run.sh's first-run setup.

Conservative on purpose: does not touch the system torch/tensorrt link surface (the -dev packages are left as-is). NEEDS HARDWARE VALIDATION — iGPU only builds via QEMU at release and there's no Jetson in CI. Draft until validated on-device.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reduced the Docker image size by removing temporary installation files and build-only packages.
  * Cleaned package manager caches during the image build.
  * Preserved all required runtime dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->