### PR TITLE
fix(ci): drop removed --device/--beam-size args from smoke test

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -128,7 +128,7 @@ When assigned a task:
 
 2. **Basic Server Start**:
    ```bash
-   python script/run --model base --uri tcp://127.0.0.1:10300 --data-dir ./data --download-dir ./download --device cuda
+   python script/run --model base --uri tcp://127.0.0.1:10300 --data-dir ./data --download-dir ./download
    ```
    - **NEVER CANCEL**: Initial run takes 30-45 minutes for model download and TensorRT optimization.
    - Set timeout to 60+ minutes for first run.
@@ -172,7 +172,7 @@ These commands help verify the codebase integrity before committing to long buil
 1. **Start Server and Verify Listening**:
    ```bash
    # Terminal 1: Start server
-   python -m wyoming_whisper_trt --model base --uri tcp://127.0.0.1:10300 --data-dir ./data --device cuda
+   python -m wyoming_whisper_trt --model base --uri tcp://127.0.0.1:10300 --data-dir ./data
    
    # Terminal 2: Test connectivity (in separate session)
    nc -z localhost 10300 && echo "Server is listening" || echo "Server not responding"
@@ -340,7 +340,7 @@ If you see `pip._vendor.urllib3.exceptions.ReadTimeoutError: HTTPSConnectionPool
 - **Required**: NVIDIA GPU with CUDA compute capability 7.0+
 - **Required**: NVIDIA Container Toolkit (for Docker)
 - **Required**: CUDA 12.8+ and TensorRT 10.13+
-- **Development**: Can fall back to CPU mode with `--device cpu` but significantly slower
+- **No CPU fallback**: TensorRT engines are GPU-only; a CUDA device is mandatory
 
 ## CI/CD Integration
 
@@ -466,7 +466,7 @@ Always use the provided Docker images for production deployments as they handle 
 **CUDA/GPU Not Detected:**
 - Verify NVIDIA drivers are installed
 - Check NVIDIA Container Toolkit configuration
-- Use `--device cpu` flag for development without GPU
+- A CUDA GPU is required; there is no CPU fallback
 
 **Test Failures:**
 - Ensure all dependencies are installed (`python script/setup --dev`)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -124,9 +124,7 @@ jobs:
             --uri $TEST_URI \
             --data-dir $DATA_DIR \
             --download-dir $DOWNLOAD_DIR \
-            --device cuda \
             --compute-type float16 \
-            --beam-size 5 \
             --language en \
             > server.log 2>&1 &
         

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,9 +11,7 @@
         "--model", "tiny",
         "--uri", "tcp://0.0.0.0:10300",
         "--data-dir", "./.vscode/data",
-        "--device", "cuda",
         "--compute-type", "float16",
-        "--beam-size", "5",
         "--language", "auto",
         "--debug"
       ],


### PR DESCRIPTION
## Problem

The `test.yml` smoke test still passed `--device cuda` and `--beam-size 5` to the server. Those options were removed from the CLI parser, so the process exited with status 2 before it ever listened:

```
__main__.py: error: unrecognized arguments: --device cuda --beam-size 5
```

## Changes

- `.github/workflows/test.yml` — drop both stale flags from the server invocation. Remaining flags (`--model`, `--uri`, `--data-dir`, `--download-dir`, `--compute-type`, `--language`) all still exist in the parser.
- `.vscode/launch.json` — same two flags removed; the debug config would have failed identically.
- `.github/copilot-instructions.md` — remove `--device cuda` from the two example commands, and replace the two claims that `--device cpu` enables a CPU fallback (TensorRT engines are GPU-only, so that flag never worked as documented).

No remaining references to either flag outside `.venv/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)