### PR TITLE
fix(build): unblock large-family engine builds (ONNX >2 GB export)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,9 @@ tensorrt~=10.16.1.11
 onnx~=1.22.0
 onnxscript~=0.7.0
 onnx-graphsurgeon==0.6.1
+# Not imported by this project directly: onnx-graphsurgeon's fold_constants()
+# evaluates constant subgraphs through onnxruntime (CPUExecutionProvider only,
+# so the GPU build would be pure image bloat). Without it every torch2trt
+# conversion logs "No module named 'onnxruntime'" and silently skips folding.
+onnxruntime~=1.28.0
 torch==2.12.1


### PR DESCRIPTION
Refs #551

## Problem

Every `large` variant (`large`, `large-v2`, `large-v3`, `large-v3-turbo`) failed during the audio encoder engine build, on every GPU:

```
File ".../torch2trt/torch2trt.py", line 636, in torch2trt
    onnx.save(gs.export_onnx(onnx_graph), tmp_out_path)
google.protobuf.message.EncodeError: Failed to serialize proto
```

## Root cause

torch2trt's `use_onnx` path wrote the post-graphsurgeon model with a plain `onnx.save()`, which serializes the whole `ModelProto` in memory. protobuf refuses to serialize any message over 2 GiB.

The large family shares one ~635M-param audio encoder, ~2.5 GB in fp32 — and ONNX export is always fp32 regardless of `--compute-type`, so `--compute-type float16` was no escape. `medium.en` (~307M) sits under the limit, which is why it built fine and only the large models were affected. Not GPU-specific.

## Changes

- **Submodule bump** to [Jonah-May-OSS/torch2trt#6][t2t]: oversized graphs are saved with ONNX external-data format, keeping the proto itself small. The size check estimates tensor payload rather than calling `ByteSize()`, which raises on exactly the models it needs to detect. TensorRT's `parse_from_file()` resolves the sidecar; the byte-oriented `parse()` fallback cannot, so that branch now raises a clear error instead of parsing a weightless graph.
- **Declare `onnxruntime~=1.28.0`.** graphsurgeon's `fold_constants()` evaluates constant subgraphs through onnxruntime. It was never declared, so in the image every conversion logged `No module named 'onnxruntime'` and skipped folding — that call has been a no-op in every shipped image. Also reported in #551. CPU build, not `onnxruntime-gpu`: graphsurgeon hardcodes `CPUExecutionProvider`.

[t2t]: https://github.com/Jonah-May-OSS/torch2trt/pull/6

## Verification

- Reproduced the reported `EncodeError` on a 2.48 GB `ModelProto`; with the fix, it saves (3.9 KB proto + 2.48 GB sidecar) and reloads correctly.
- Constant folding is load-bearing, not cosmetic: a two-node graph with a foldable `Add` folds to one node with onnxruntime present, stays at two (and warns) with the import blocked.
- onnxruntime 1.28.0 checked against the image target — cp312 `manylinux_2_28` wheel (base is Ubuntu 24.04 / glibc 2.39), deps don't collide with the `onnx~=1.22.0` pin, fold test passes on a clean venv.

## Not verified

No end-to-end `large-v3-turbo` build has been run on real hardware — the above is all synthetic. This fixes the **export**; a 16 GB card could still hit a distinct memory wall later in the build. That would be a separate issue, not a regression here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added ONNX Runtime as a required component for CPU-based model processing.
  * Updated the model conversion tooling to a newer revision for improved compatibility and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->