### PR TITLE
fix(cache): key TRT engine checkpoints by GPU compute capability

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,20 +88,19 @@ jobs:
           # Define server URI for testing
           TEST_URI="tcp://127.0.0.1:8080"
 
-          # Data (built TRT engine) and model download dirs. Point them at the
-          # persistent runner cache when available so the expensive TRT engine
-          # build + model download are reused across runs; fall back to local
-          # dirs on runners without the cache mount.
+          # Data and model download dirs. Point them at the persistent runner
+          # cache when available so the expensive TRT engine build + model
+          # download are reused across runs; fall back to local dirs on runners
+          # without the cache mount.
           #
-          # TRT engine plans are GPU-architecture specific, and the runner pool
-          # has mixed GPUs (e.g. sm_89 RTX 4070 Ti and sm_86 RTX 3050). Key the
-          # engine cache (--data-dir) by compute capability so a plan built on
-          # one arch is never deserialized on another (TRT "incompatible device"
-          # error 6). The download-dir holds arch-independent model weights and
-          # stays shared.
+          # The runner pool has mixed GPUs (e.g. sm_89 RTX 4070 Ti and sm_86 RTX
+          # 3050) and TRT engine plans are architecture specific. The engine
+          # checkpoint lands in --download-dir, and its filename now carries the
+          # compute capability of the device torch selects, so runners of
+          # different archs can share these dirs without one deserializing the
+          # other's plan (TRT "incompatible device" error 6).
           if [ -n "$RUNNER_CACHE" ]; then
-            CC="$(nvidia-smi --query-gpu=compute_cap --format=csv,noheader 2>/dev/null | head -1 | tr -cd '0-9')"
-            DATA_DIR="$RUNNER_CACHE/whisper/data-sm${CC:-unknown}"
+            DATA_DIR="$RUNNER_CACHE/whisper/data"
             DOWNLOAD_DIR="$RUNNER_CACHE/whisper/download"
           else
             DATA_DIR="./data"

--- a/run.sh
+++ b/run.sh
@@ -35,19 +35,13 @@ else
     echo "torch2trt is already installed. Skipping setup."
 fi
 
-# TRT engine plans are GPU-architecture specific. Suffix the engine dir with
-# the GPU's compute capability so a plan built on one arch is never loaded on
-# another (TRT deserialize "incompatible device" Error 6) if the container is
-# rescheduled onto a different GPU. Model weights are arch-independent; only
-# the engine cache (--data-dir) is keyed. Falls back to the bare dir when
-# nvidia-smi is unavailable.
-BASE_DATA_DIR="${DATA_DIR:-/data}"
-GPU_CC="$(nvidia-smi --query-gpu=compute_cap --format=csv,noheader 2>/dev/null | head -1 | tr -cd '0-9')"
-if [ -n "$GPU_CC" ]; then
-    ENGINE_DATA_DIR="${BASE_DATA_DIR}/sm${GPU_CC}"
-else
-    ENGINE_DATA_DIR="${BASE_DATA_DIR}"
-fi
+# TRT engine plans are GPU-architecture specific, so a plan built on one arch
+# must never be loaded on another (TRT deserialize "incompatible device" Error
+# 6) if the container is rescheduled onto a different GPU. The compute
+# capability of the device torch actually selects is baked into the cached
+# engine filename (e.g. base_en_trt_float16_kv4_ws1024_sm86.pth), so a single
+# data dir is safe to share across GPUs — no directory keying needed here.
+ENGINE_DATA_DIR="${DATA_DIR:-/data}"
 mkdir -p "$ENGINE_DATA_DIR"
 echo "Using engine data dir: $ENGINE_DATA_DIR"
 

--- a/tests/test_engine_cache.py
+++ b/tests/test_engine_cache.py
@@ -1,0 +1,165 @@
+"""Unit tests for GPU-architecture keying of the cached TRT engine.
+
+TensorRT engine plans are only valid on the compute capability they were built
+on, so the arch tag is part of the cache filename and a plan that still fails to
+deserialize is discarded and rebuilt once. These tests mock the CUDA capability
+query and the builder, so they run on CPU-only CI runners (no real GPU needed).
+"""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from whisper_trt import IncompatibleEngineError, get_device_arch_tag
+from whisper_trt.model import get_model_filename, load_trt_model
+
+
+def _capability(major: int, minor: int):
+    """Patch the CUDA capability query to report ``major.minor``."""
+    return patch(
+        "whisper_trt.model.torch.cuda.get_device_capability",
+        return_value=(major, minor),
+    )
+
+
+def _cuda_available(available: bool):
+    return patch(
+        "whisper_trt.model.torch.cuda.is_available",
+        return_value=available,
+    )
+
+
+class TestDeviceArchTag:
+    """``get_device_arch_tag`` reports the device torch itself selects."""
+
+    def test_reports_compute_capability(self) -> None:
+        with _cuda_available(True), _capability(8, 6):
+            assert get_device_arch_tag() == "sm86"
+
+    def test_falls_back_when_cuda_is_unavailable(self) -> None:
+        with _cuda_available(False):
+            assert get_device_arch_tag() == "smunknown"
+
+    def test_falls_back_when_the_driver_query_fails(self) -> None:
+        with (
+            _cuda_available(True),
+            patch(
+                "whisper_trt.model.torch.cuda.get_device_capability",
+                side_effect=RuntimeError("no CUDA driver"),
+            ),
+        ):
+            assert get_device_arch_tag() == "smunknown"
+
+
+class TestArchKeyedFilename:
+    """The cache filename separates plans built on different architectures."""
+
+    def test_filename_carries_the_arch_tag(self) -> None:
+        with _cuda_available(True), _capability(8, 6):
+            assert (
+                get_model_filename(
+                    "base.en", "float16", decoder_mode="kv", max_workspace_mb=1024
+                )
+                == "base_en_trt_float16_kv4_ws1024_sm86.pth"
+            )
+
+    def test_different_archs_never_share_a_filename(self) -> None:
+        """The regression: an sm_86 plan must not be picked up on an sm_89 GPU."""
+        args = ("base.en", "float16")
+        kwargs = {"decoder_mode": "kv", "max_workspace_mb": 1024}
+        with _cuda_available(True), _capability(8, 6):
+            on_sm86 = get_model_filename(*args, **kwargs)
+        with _cuda_available(True), _capability(8, 9):
+            on_sm89 = get_model_filename(*args, **kwargs)
+        assert on_sm86 != on_sm89
+
+
+class _FakeModel:
+    """Stand-in for a loaded WhisperTRT; only the warm-up call is exercised."""
+
+    def transcribe(self, *_args, **_kwargs) -> dict[str, str]:
+        return {"text": ""}
+
+
+class _FakeBuilder:
+    """Builder stub that fails to deserialize until the cache is rebuilt."""
+
+    def __init__(self, path: Path, fail_loads: int) -> None:
+        self._path = path
+        self._remaining_failures = fail_loads
+        self.builds = 0
+        self.loads = 0
+
+    def build(self, path: str, verbose: bool = False) -> None:
+        self.builds += 1
+        Path(path).write_bytes(b"engine")
+
+    def load(self, path: str) -> _FakeModel:
+        self.loads += 1
+        if not Path(path).exists():
+            raise FileNotFoundError(path)
+        if self._remaining_failures > 0:
+            self._remaining_failures -= 1
+            raise IncompatibleEngineError("expecting compute 8.6 got compute 8.9")
+        return _FakeModel()
+
+
+@pytest.fixture(name="cached_engine")
+def _cached_engine(tmp_path: Path) -> Path:
+    """A pre-existing (stale) engine checkpoint in a shared cache dir."""
+    path = tmp_path / "base_en_trt_float16_kv4_ws1024_sm86.pth"
+    path.write_bytes(b"stale engine from another GPU")
+    return path
+
+
+def _load(path: Path, builder: _FakeBuilder, *, build: bool):
+    """Invoke load_trt_model with the builder stubbed and warm-up disabled."""
+    with patch.dict(
+        "whisper_trt.model.MODEL_BUILDERS", {"base.en": builder}, clear=False
+    ):
+        return load_trt_model("base.en", path=str(path), build=build)
+
+
+class TestIncompatibleEngineRecovery:
+    """A plan that cannot deserialize here is rebuilt once, not crashed on."""
+
+    def test_rebuilds_once_and_replaces_the_dead_cache(self, cached_engine) -> None:
+        builder = _FakeBuilder(cached_engine, fail_loads=1)
+        model = _load(cached_engine, builder, build=True)
+
+        assert model is not None
+        assert builder.builds == 1, "should rebuild exactly once"
+        assert builder.loads == 2, "one failed load, then one after the rebuild"
+        assert cached_engine.read_bytes() == b"engine", "stale plan was replaced"
+
+    def test_propagates_when_building_is_disabled(self, cached_engine) -> None:
+        builder = _FakeBuilder(cached_engine, fail_loads=1)
+        with pytest.raises(IncompatibleEngineError):
+            _load(cached_engine, builder, build=False)
+        assert builder.builds == 0
+        assert cached_engine.exists(), "cache must be left alone when build=False"
+
+    def test_does_not_retry_forever(self, cached_engine) -> None:
+        """A rebuild that still won't deserialize surfaces rather than looping."""
+        builder = _FakeBuilder(cached_engine, fail_loads=2)
+        with pytest.raises(IncompatibleEngineError):
+            _load(cached_engine, builder, build=True)
+        assert builder.builds == 1
+
+    def test_tolerates_a_concurrent_process_unlinking_the_cache(
+        self, cached_engine
+    ) -> None:
+        """Two processes sharing a cache dir can both discard the same file."""
+        builder = _FakeBuilder(cached_engine, fail_loads=1)
+        original_load = builder.load
+
+        def load_then_race(path: str) -> object:
+            try:
+                return original_load(path)
+            finally:
+                Path(path).unlink(missing_ok=True)  # the other process got there first
+
+        with patch.object(builder, "load", side_effect=load_then_race):
+            model = _load(cached_engine, builder, build=True)
+        assert model is not None

--- a/whisper_trt/__init__.py
+++ b/whisper_trt/__init__.py
@@ -26,9 +26,11 @@ from .cache import get_cache_dir, set_cache_dir
 from .model import (
     LARGE_MODELS,
     MODEL_FILENAMES,
+    IncompatibleEngineError,
     WhisperTRT,
     WhisperTRTBuilder,
     auto_workspace_mb,
+    get_device_arch_tag,
     get_model_filename,
     load_trt_model,
 )
@@ -36,11 +38,13 @@ from .model import (
 __all__ = [
     "LARGE_MODELS",
     "MODEL_FILENAMES",
+    "IncompatibleEngineError",
     "WhisperTRT",
     "WhisperTRTBuilder",
     "__version__",
     "auto_workspace_mb",
     "get_cache_dir",
+    "get_device_arch_tag",
     "get_model_filename",
     "load_trt_model",
     "set_cache_dir",

--- a/whisper_trt/model.py
+++ b/whisper_trt/model.py
@@ -85,6 +85,54 @@ def _instantiate_type(class_type: type[Any]) -> Any:
     return class_type()
 
 
+class IncompatibleEngineError(RuntimeError):
+    """Raised when a serialized TRT engine cannot be deserialized here.
+
+    The usual cause is a checkpoint built for a different GPU architecture
+    (TensorRT plans are not portable across compute capabilities), but a
+    truncated or TRT-version-mismatched plan fails the same way.
+    """
+
+
+def get_device_arch_tag() -> str:
+    """Return a cache tag for the CUDA device this process will actually use.
+
+    TensorRT plans are tied to the compute capability they were built on, so
+    the tag becomes part of the engine filename: a plan built on an sm_86 GPU
+    can never be picked up on an sm_89 one, even when both share a cache
+    directory. Derived from the device torch selects rather than from
+    ``nvidia-smi``, whose ordering need not match CUDA's on mixed multi-GPU
+    hosts.
+    """
+    try:
+        if not torch.cuda.is_available():
+            return "smunknown"
+        major, minor = torch.cuda.get_device_capability()
+    except (RuntimeError, AssertionError) as err:  # pragma: no cover - driver dependent
+        logger.debug("Could not query CUDA compute capability: %s", err)
+        return "smunknown"
+    return f"sm{major}{minor}"
+
+
+def _load_engine_module(engine_state: dict[str, Any], what: str) -> Any:
+    """Deserialize one TRT engine from checkpoint state into a TRTModule.
+
+    ``TRTModule._load_from_state_dict`` leaves ``engine`` as ``None`` when
+    ``deserialize_cuda_engine`` fails, which otherwise only surfaces later as
+    an opaque ``AttributeError`` on ``NoneType``. Convert it here into an
+    actionable error the loader can respond to by rebuilding.
+    """
+    module = _new_trt_module().cuda()
+    module.load_state_dict(engine_state)
+    if getattr(module, "engine", None) is None:
+        raise IncompatibleEngineError(
+            f"Failed to deserialize the '{what}' TensorRT engine on this device "
+            f"({get_device_arch_tag()}); the cached plan is incompatible or corrupt "
+            "and must be rebuilt. See the TensorRT log above for the exact cause."
+        )
+    return module
+
+
 def _invoke_converter(
     converter: Callable[..., Any],
     module: nn.Module,
@@ -1178,8 +1226,9 @@ class WhisperTRTBuilder:
         checkpoint: dict[str, Any],
     ) -> AudioEncoderTRT:
         """Construct AudioEncoderTRT from a serialized checkpoint."""
-        audio_encoder_engine = _new_trt_module().cuda()
-        audio_encoder_engine.load_state_dict(checkpoint["audio_encoder_engine"])
+        audio_encoder_engine = _load_engine_module(
+            checkpoint["audio_encoder_engine"], "audio_encoder"
+        )
         audio_state = checkpoint["audio_encoder_extra_state"]
         return AudioEncoderTRT(
             audio_encoder_engine,
@@ -1218,16 +1267,16 @@ class WhisperTRTBuilder:
         """Construct the runtime text decoder matching the checkpoint's mode."""
         state = cls._load_text_decoder_state(checkpoint, dims)
         if checkpoint.get("decoder_mode") == "simple":
-            engine = _new_trt_module().cuda()
-            engine.load_state_dict(checkpoint["text_decoder_engine"])
+            engine = _load_engine_module(
+                checkpoint["text_decoder_engine"], "text_decoder"
+            )
             return TextDecoderTRT(engine, state)
 
-        cross_kv_engine = _new_trt_module().cuda()
-        cross_kv_engine.load_state_dict(checkpoint["cross_kv_engine"])
-        prefill_engine = _new_trt_module().cuda()
-        prefill_engine.load_state_dict(checkpoint["prefill_engine"])
-        step_engine = _new_trt_module().cuda()
-        step_engine.load_state_dict(checkpoint["decoder_step_engine"])
+        cross_kv_engine = _load_engine_module(checkpoint["cross_kv_engine"], "cross_kv")
+        prefill_engine = _load_engine_module(checkpoint["prefill_engine"], "prefill")
+        step_engine = _load_engine_module(
+            checkpoint["decoder_step_engine"], "decoder_step"
+        )
         return TextDecoderTRTKV(
             DecoderEngines(
                 cross_kv=cross_kv_engine,
@@ -1384,10 +1433,13 @@ def get_model_filename(
     Returns the compute-type- and decoder-mode-aware cached engine filename.
 
     Each distinct compute type (float32, float16, int8), decoder mode (kv,
-    simple), and workspace budget produces a separate cached engine file,
-    preventing silent reuse of an engine built under different settings. The
-    engine-schema tag additionally invalidates caches whose serialized layout
-    no longer matches the loader.
+    simple), workspace budget, and GPU architecture produces a separate cached
+    engine file, preventing silent reuse of an engine built under different
+    settings. The engine-schema tag additionally invalidates caches whose
+    serialized layout no longer matches the loader, and the ``sm<cc>`` tag keeps
+    a plan built on one compute capability from being loaded on another (TRT
+    deserialize "incompatible device" error 6) even when several machines share
+    one cache directory.
 
     Args:
         name (str): The model name (e.g. "tiny", "base.en").
@@ -1399,7 +1451,7 @@ def get_model_filename(
 
     Returns:
         str: Filename with the quant mode, schema, and workspace embedded
-            (e.g. "tiny_trt_float16_kv4_ws1024.pth").
+            (e.g. "tiny_trt_float16_kv4_ws1024_sm89.pth").
 
     Raises:
         RuntimeError: If ``name`` is not a recognised model name or if
@@ -1420,7 +1472,7 @@ def get_model_filename(
     )
     base = MODEL_FILENAMES[name]
     stem, ext = os.path.splitext(base)
-    return f"{stem}_{quant_mode}_{schema}_ws{workspace_mb}{ext}"
+    return f"{stem}_{quant_mode}_{schema}_ws{workspace_mb}_{get_device_arch_tag()}{ext}"
 
 
 def load_trt_model(
@@ -1459,7 +1511,19 @@ def load_trt_model(
             raise RuntimeError(f"No model found at {path}; pass build=True.")
         builder.build(path, verbose=verbose)
 
-    trt_model = builder.load(path)
+    try:
+        trt_model = builder.load(path)
+    except IncompatibleEngineError as err:
+        # The cached plan cannot run here (built for another GPU arch, or a
+        # different TRT version, or truncated). Filenames are arch-keyed, so
+        # this should be rare, but discard the unusable file and rebuild once
+        # rather than dying on a cache we know is dead.
+        if not build:
+            raise
+        logger.warning("Rebuilding unusable TRT checkpoint at %s: %s", path, err)
+        os.remove(path)  # engine checkpoints are multi-GB; don't keep a dead copy
+        builder.build(path, verbose=verbose)
+        trt_model = builder.load(path)
 
     try:
         silence = np.zeros((whisper.audio.N_SAMPLES,), dtype=np.float32)

--- a/whisper_trt/model.py
+++ b/whisper_trt/model.py
@@ -36,6 +36,7 @@ import time
 import wave
 from collections.abc import Callable
 from dataclasses import asdict, dataclass
+from pathlib import Path
 from typing import Any, cast
 
 import numpy as np
@@ -1521,7 +1522,10 @@ def load_trt_model(
         if not build:
             raise
         logger.warning("Rebuilding unusable TRT checkpoint at %s: %s", path, err)
-        os.remove(path)  # engine checkpoints are multi-GB; don't keep a dead copy
+        # Engine checkpoints are multi-GB, so drop the dead copy rather than
+        # renaming it aside. missing_ok: another process sharing this cache dir
+        # may have reached the same conclusion and unlinked it first.
+        Path(path).unlink(missing_ok=True)
         builder.build(path, verbose=verbose)
         trt_model = builder.load(path)
 

--- a/wyoming_whisper_trt/__main__.py
+++ b/wyoming_whisper_trt/__main__.py
@@ -440,6 +440,10 @@ async def main() -> None:
     # Load Whisper TRT model
     try:
         logger.info("Loading Whisper TRT model '%s'...", model_name)
+        # The built TRT engine checkpoint lives in the download dir. Its
+        # filename encodes compute type, decoder mode, workspace budget, and the
+        # GPU compute capability, so a dir shared between machines with
+        # different GPUs never yields an engine this device can't deserialize.
         model_path = os.path.join(
             args.download_dir,
             get_model_filename(


### PR DESCRIPTION
CI failed on a mixed-GPU runner pool with TRT "The engine plan file is generated on an incompatible device, expecting compute 8.6 got compute 8.9", surfacing as an opaque `AttributeError: 'NoneType' object has no attribute 'create_execution_context'`.

Both run.sh and the CI workflow tried to guard against this by suffixing --data-dir with the compute capability, but that guard never applied: the engine checkpoint path is built from --download-dir (see `__main__.main`), and --data-dir is only ever used as the fallback default for it. In CI both flags are set explicitly, so every runner wrote its plan into the shared, un-keyed download dir and then tried to deserialize whichever arch happened to build it first.

Key the checkpoint where the other build-sensitive settings are already keyed — the filename — using the compute capability of the device torch actually selects (`torch.cuda.get_device_capability`) rather than `nvidia-smi | head -1`, whose ordering need not match CUDA's on multi-GPU hosts:

    base_en_trt_float16_kv4_ws1024_sm86.pth

This makes any shared cache dir safe regardless of launcher, so the now-redundant directory keying is dropped from run.sh and test.yml.

Also make the failure legible and self-healing: torch2trt's `_load_from_state_dict` leaves `engine` as None when `deserialize_cuda_engine` fails, so wrap every engine load and raise `IncompatibleEngineError` instead. `load_trt_model` catches it, discards the dead checkpoint, and rebuilds once rather than crashing on a cache it knows is unusable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GPU compatibility checks when loading cached engines.
  * Automatically removes incompatible cached engines and rebuilds them when needed.
  * Prevented mixed GPU architectures from accidentally reusing incompatible engine files.

* **Improvements**
  * Engine and model downloads now use a shared persistent cache location.
  * Cache entries are separated by GPU architecture for safer reuse.
  * Added clearer public error reporting for incompatible engines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->