### PR TITLE
feat(trt11): migrate to TensorRT 11 with explicit INT8 quantization

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -339,7 +339,8 @@ If you see `pip._vendor.urllib3.exceptions.ReadTimeoutError: HTTPSConnectionPool
 
 - **Required**: NVIDIA GPU with CUDA compute capability 7.0+
 - **Required**: NVIDIA Container Toolkit (for Docker)
-- **Required**: CUDA 12.8+ and TensorRT 10.13+
+- **Required**: CUDA 12.8+ and TensorRT 11.0+ (11 removed weak typing, so
+  precision is expressed in the ONNX graph — see `whisper_trt/_quant.py`)
 - **No CPU fallback**: TensorRT engines are GPU-only; a CUDA device is mandatory
 
 ## CI/CD Integration

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ docker run \
   -p 10300:10300 \                            # map port 10300 → 10300
   -e MODEL=base \                             # which model to load (tiny, small, base, etc.)
   -e LANGUAGE=auto \                          # default transcription language (`auto` = detect)
-  -e COMPUTE_TYPE=float16 \                   # float16, float32, or int8 (int8 = experimental, encoder-only INT8 + FP16 decoder)
+  -e COMPUTE_TYPE=float16 \                   # float16, float32, or int8 (int8 = experimental, encoder-only INT8 + FP16 decoder, x86 only)
   -e DECODER_MODE=kv \                        # kv (fast, ~1 GB VRAM) or simple (lean, ~200 MB less)
   -e DEVICE=cuda \                            # `cuda` or `cpu`
   captnspdr/wyoming-whisper-trt:latest
@@ -189,7 +189,7 @@ docker run \
   -p 10300:10300 \                            # map port 10300 → 10300
   -e MODEL=base \                             # which model to load (tiny, small, base, etc.)
   -e LANGUAGE=auto \                          # default transcription language (`auto` = detect)
-  -e COMPUTE_TYPE=float16 \                   # float16, float32, or int8 (int8 = experimental, encoder-only INT8 + FP16 decoder)
+  -e COMPUTE_TYPE=float16 \                   # float16 or float32 (int8 needs ModelOpt, unavailable on JetPack)
   -e DECODER_MODE=kv \                        # kv (fast, ~1 GB VRAM) or simple (lean, ~200 MB less)
   -e DEVICE=cuda \                            # `cuda` or `cpu`
   captnspdr/wyoming-whisper-trt:latest-igpu
@@ -298,26 +298,50 @@ GPU-side mel, fewer host syncs); the KV cache itself is the last ~14 %.
 
 #### A note on `int8`
 
-`COMPUTE_TYPE=int8` requests TensorRT *implicit* INT8 quantization for the
-encoder (the decoder always stays FP16). Implicit quantization is per-layer
-optional — TensorRT only uses INT8 where it times faster than FP16 — and it
-is deprecated in TensorRT 10. Measured with the tools above (default `kv`
-decoder):
+`COMPUTE_TYPE=int8` quantizes the audio encoder's convolutions and linear
+projections to INT8 and leaves everything else — attention matmuls, layer
+norms, and the whole text decoder — in FP16. Quantization is *explicit*: the
+encoder's Q/DQ pairs are inserted and calibrated (per-channel INT8 weights,
+per-tensor INT8 activations) with [NVIDIA
+ModelOpt](https://github.com/NVIDIA/TensorRT-Model-Optimizer) before the ONNX
+export, on real speech mels from the clips bundled in
+`whisper_trt/calibration/`. Add your own 16 kHz mono WAVs there to widen
+acoustic coverage.
 
-| `base`, 300 utterances (RTX 3050, TensorRT 10) | float16 | int8 |
+Explicit quantization is the only kind TensorRT 11 supports — implicit
+quantization, where the builder ran a calibrator and then used INT8 only where
+it timed faster than FP16, was removed. That removal also fixed the old
+surprise on TensorRT 10: an int8 build could come out with *zero* INT8 layers,
+byte-for-byte equivalent to float16, because no INT8 tactic won on timing.
+Q/DQ pairs are honoured regardless of tactic timings, so INT8 now actually
+takes.
+
+`int8` is x86/dGPU only. The iGPU (Jetson) image runs against JetPack's own
+TensorRT and PyTorch, which are too old for ModelOpt, so it installs without it
+and `COMPUTE_TYPE=int8` fails there with an explanatory error — use `float16`.
+
+It is still a speed/accuracy trade rather than a free win, and it has not been
+re-measured on the explicit path — INT8 activations cost accuracy that only
+your own audio can quantify, and small encoders may not be FLOP-bound enough
+to gain. Before running it in production, measure on your hardware:
+
+```bash
+./script/benchmark --model base --compute-type float16 int8 \
+    --eval-dir ./eval --data-dir ./local --detailed-build --force-rebuild
+./script/layer_report --model base --compute-type int8 --data-dir ./local
+```
+
+For reference, the numbers that motivated the change (`base`, 300 utterances,
+RTX 3050, TensorRT 10, implicit quantization) — the int8 column is what
+explicit Q/DQ replaces:
+
+| `base`, 300 utterances (RTX 3050, TensorRT 10) | float16 | int8 (implicit) |
 |---|---|---|
 | WER | 5.37 % | 5.37 % |
 | Latency p95 | 0.124 s | 0.124 s |
 | VRAM (nvidia-smi) | 1032 MiB | 1032 MiB |
 | Encoder engine size | 40.0 MiB | 40.2 MiB |
 | INT8 layers in engine | — | 0 of 105 |
-
-In other words: on this hardware the int8 engine is identical to float16 and
-just takes longer to build (WER differences are within run-to-run noise).
-Other GPU/TensorRT combinations may behave differently — run
-`script/layer_report` on your own hardware before assuming any benefit.
-Guaranteed quantization would require explicit Q/DQ (e.g. via
-nvidia-modelopt), which only pays off on `medium`/`large` encoders.
 
 #### Silence hallucination suppression
 

--- a/README.md
+++ b/README.md
@@ -298,15 +298,19 @@ GPU-side mel, fewer host syncs); the KV cache itself is the last ~14 %.
 
 #### A note on `int8`
 
-`COMPUTE_TYPE=int8` quantizes the audio encoder's convolutions and linear
-projections to INT8 and leaves everything else — attention matmuls, layer
-norms, and the whole text decoder — in FP16. Quantization is *explicit*: the
-encoder's Q/DQ pairs are inserted and calibrated (per-channel INT8 weights,
-per-tensor INT8 activations) with [NVIDIA
-ModelOpt](https://github.com/NVIDIA/TensorRT-Model-Optimizer) before the ONNX
-export, on real speech mels from the clips bundled in
-`whisper_trt/calibration/`. Add your own 16 kHz mono WAVs there to widen
-acoustic coverage.
+`COMPUTE_TYPE=int8` quantizes the audio encoder's convolutions and matmuls to
+INT8 and leaves everything else — layer norms, softmax, and the whole text
+decoder — in FP16. Quantization is *explicit*: after the encoder is exported to
+ONNX, [NVIDIA ModelOpt](https://github.com/NVIDIA/TensorRT-Model-Optimizer)
+rewrites the graph with Q/DQ pairs whose activation ranges were calibrated on
+real speech mels — from the clips bundled in `whisper_trt/calibration/`, so add
+your own 16 kHz mono WAVs there to widen acoustic coverage — and casts the
+unquantized remainder to FP16 in the same pass. Graph inputs and outputs stay
+FP32, so nothing changes at the runtime boundary.
+
+Calibration replays the graph through onnxruntime on the **CPU** (the image
+ships CPU-only onnxruntime), so an int8 build is slower than a float16 one by
+roughly one CPU encoder pass per clip — noticeable on `medium`/`large`.
 
 Explicit quantization is the only kind TensorRT 11 supports — implicit
 quantization, where the builder ran a calibrator and then used INT8 only where

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,8 +6,10 @@ tensorrt_cu13_libs~=11.2.1.2
 tensorrt~=11.2.1.2
 # TensorRT 11 removed weak typing: the FP16/INT8 builder flags are gone and
 # precision has to be expressed in the ONNX graph handed to the parser. ModelOpt
-# does both halves of that — AutoCast rewrites the graph to FP16, and its torch
-# quantizers bake INT8 Q/DQ pairs into the encoder (see whisper_trt/_quant.py).
+# rewrites the graph for both — AutoCast casts an FP32 graph to FP16, and the
+# ONNX quantizer inserts INT8 Q/DQ (casting the remainder to FP16 in the same
+# pass). Both run inside torch2trt's ONNX export path; whisper_trt/_quant.py
+# only reports whether they are importable.
 nvidia-modelopt~=0.45.0
 # ModelOpt's ONNX subpackage imports these eagerly but only declares them under
 # its heavyweight [onnx] extra, which would also drag in cupy and
@@ -16,6 +18,10 @@ ml_dtypes~=0.5.4
 polygraphy~=0.53.4
 onnxslim~=0.1.95
 lief~=1.0.0
+# Deliberately ahead of the onnx~=1.21 that ModelOpt's [onnx] extra asks for:
+# that extra is not installed (see above), nothing else here constrains onnx,
+# and the ONNX rewrites ModelOpt performs are covered against the installed
+# version by tests/test_quant.py. Revisit the pin if those start failing.
 onnx~=1.22.0
 onnxscript~=0.7.0
 onnx-graphsurgeon==0.6.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,21 @@
 --extra-index-url https://pypi.nvidia.com
 wyoming==1.10.0
 openai-whisper==20250625
-tensorrt_cu13_bindings~=10.16.1.11
-tensorrt_cu13_libs~=10.16.1.11
-tensorrt~=10.16.1.11
+tensorrt_cu13_bindings~=11.2.1.2
+tensorrt_cu13_libs~=11.2.1.2
+tensorrt~=11.2.1.2
+# TensorRT 11 removed weak typing: the FP16/INT8 builder flags are gone and
+# precision has to be expressed in the ONNX graph handed to the parser. ModelOpt
+# does both halves of that — AutoCast rewrites the graph to FP16, and its torch
+# quantizers bake INT8 Q/DQ pairs into the encoder (see whisper_trt/_quant.py).
+nvidia-modelopt~=0.45.0
+# ModelOpt's ONNX subpackage imports these eagerly but only declares them under
+# its heavyweight [onnx] extra, which would also drag in cupy and
+# onnxruntime-gpu (hundreds of MB the image does not need).
+ml_dtypes~=0.5.4
+polygraphy~=0.53.4
+onnxslim~=0.1.95
+lief~=1.0.0
 onnx~=1.22.0
 onnxscript~=0.7.0
 onnx-graphsurgeon==0.6.1

--- a/run.sh
+++ b/run.sh
@@ -43,10 +43,11 @@ fi
 # must never be loaded on another (TRT deserialize "incompatible device" Error
 # 6) if the container is rescheduled onto a different GPU. The compute
 # capability of the device torch actually selects is baked into the cached
-# engine filename (e.g. base_en_trt_float16_kv4_ws1024_sm86_trt11.pth), so a
-# single data dir is safe to share across GPUs — no directory keying needed
-# here. The trailing tag is the TensorRT major version, whose plans are just as
-# non-interchangeable, so upgrading TensorRT builds a new engine instead of
+# engine filename (e.g. base_en_trt_float16_kv4_ws1024_sm86_trt11_2_1_2.pth),
+# so a single data dir is safe to share across GPUs — no directory keying needed
+# here. The trailing tag is the TensorRT version, whose plans are just as
+# non-interchangeable (engines are not built VERSION_COMPATIBLE, so even a patch
+# bump needs its own plan), so upgrading TensorRT builds a new engine instead of
 # failing to load the old one.
 ENGINE_DATA_DIR="${DATA_DIR:-/data}"
 mkdir -p "$ENGINE_DATA_DIR"

--- a/run.sh
+++ b/run.sh
@@ -12,9 +12,13 @@ if [ ! -d ".venv" ]; then
     if [ "${NVIDIA_EMBEDDED:-false}" = "true" ]; then
     echo "NVIDIA_EMBEDDED is true. Adjusting setup for embedded environment..."
     # Remove tensorrt and torch from requirements.txt if NVIDIA_EMBEDDED is true
-    # This is necessary because the torch and tensorrt packages installed on NVIDIA embedded devices are not compatible 
+    # This is necessary because the torch and tensorrt packages installed on NVIDIA embedded devices are not compatible
     # with the versions specified in requirements.txt, and attempting to install them will cause conflicts and break the setup process.
-        sed -i '/tensorrt/d;/torch/d' requirements.txt
+    # nvidia-modelopt (and the ONNX packages it needs) go with them: it requires
+    # torch >= 2.8, so pip would try to pull a fresh torch over JetPack's. That
+    # only costs COMPUTE_TYPE=int8, which needs ModelOpt to insert its Q/DQ —
+    # float16 and float32 build fine without it on JetPack's TensorRT 10.
+        sed -i '/tensorrt/d;/torch/d;/nvidia-modelopt/d;/ml_dtypes/d;/polygraphy/d;/onnxslim/d;/lief/d' requirements.txt
     # Enable system site packages so VENV can access TensorRT and PyTorch installed on the system
         setup_args+=(--system_site_packages)
     fi
@@ -39,8 +43,11 @@ fi
 # must never be loaded on another (TRT deserialize "incompatible device" Error
 # 6) if the container is rescheduled onto a different GPU. The compute
 # capability of the device torch actually selects is baked into the cached
-# engine filename (e.g. base_en_trt_float16_kv4_ws1024_sm86.pth), so a single
-# data dir is safe to share across GPUs — no directory keying needed here.
+# engine filename (e.g. base_en_trt_float16_kv4_ws1024_sm86_trt11.pth), so a
+# single data dir is safe to share across GPUs — no directory keying needed
+# here. The trailing tag is the TensorRT major version, whose plans are just as
+# non-interchangeable, so upgrading TensorRT builds a new engine instead of
+# failing to load the old one.
 ENGINE_DATA_DIR="${DATA_DIR:-/data}"
 mkdir -p "$ENGINE_DATA_DIR"
 echo "Using engine data dir: $ENGINE_DATA_DIR"

--- a/tests/test_engine_cache.py
+++ b/tests/test_engine_cache.py
@@ -40,18 +40,32 @@ def _trt_version(version: str):
     return patch("whisper_trt.model.tensorrt.__version__", version)
 
 
+def _tag_for(version: str) -> str:
+    with _trt_version(version):
+        return get_trt_version_tag()
+
+
 class TestTrtVersionTag:
-    """``get_trt_version_tag`` keys the cache on the TensorRT major version."""
+    """``get_trt_version_tag`` keys the cache on the exact TensorRT version."""
 
-    def test_reports_the_major_version(self) -> None:
+    def test_reports_the_full_version(self) -> None:
         with _trt_version("11.2.1.2"):
-            assert get_trt_version_tag() == "trt11"
+            assert get_trt_version_tag() == "trt11_2_1_2"
 
-    def test_minor_upgrades_share_a_tag(self) -> None:
-        with _trt_version("11.0.0.114"):
-            first = get_trt_version_tag()
-        with _trt_version("11.2.1.2"):
-            assert get_trt_version_tag() == first
+    def test_distinct_releases_never_share_a_tag(self) -> None:
+        """Engines are not VERSION_COMPATIBLE, so even a patch bump needs its own
+        plan: 11.2.1 cannot deserialize what 11.0.0 built."""
+        tags = {
+            _tag_for(version)
+            for version in ("11.0.0.114", "11.1.0.106", "11.2.1.2", "10.16.1.11")
+        }
+        assert len(tags) == 4
+
+    def test_suffixed_versions_stay_filename_safe(self) -> None:
+        """Post/dev releases reach the filename with no dots or plus signs."""
+        tag = _tag_for("10.7.0.post1")
+        assert tag == "trt10_7_0_post1"
+        assert tag.replace("_", "").isalnum()
 
 
 class TestDeviceArchTag:
@@ -85,19 +99,21 @@ class TestArchKeyedFilename:
                 get_model_filename(
                     "base.en", "float16", decoder_mode="kv", max_workspace_mb=1024
                 )
-                == "base_en_trt_float16_kv4_ws1024_sm86_trt11.pth"
+                == "base_en_trt_float16_kv4_ws1024_sm86_trt11_2_1_2.pth"
             )
 
-    def test_different_trt_majors_never_share_a_filename(self) -> None:
-        """A TensorRT 10 plan must not be handed to TensorRT 11, which cannot load it."""
+    def test_different_trt_versions_never_share_a_filename(self) -> None:
+        """A plan must never be handed to a TensorRT build that cannot load it."""
         args = ("base.en", "float16")
         kwargs = {"decoder_mode": "kv", "max_workspace_mb": 1024}
         with _cuda_available(True), _capability(8, 6):
-            with _trt_version("10.16.1.11"):
-                on_trt10 = get_model_filename(*args, **kwargs)
+            with _trt_version("11.0.0.114"):
+                on_11_0 = get_model_filename(*args, **kwargs)
             with _trt_version("11.2.1.2"):
-                on_trt11 = get_model_filename(*args, **kwargs)
-        assert on_trt10 != on_trt11
+                on_11_2 = get_model_filename(*args, **kwargs)
+            with _trt_version("10.16.1.11"):
+                on_10 = get_model_filename(*args, **kwargs)
+        assert len({on_11_0, on_11_2, on_10}) == 3
 
     def test_different_archs_never_share_a_filename(self) -> None:
         """The regression: an sm_86 plan must not be picked up on an sm_89 GPU."""

--- a/tests/test_engine_cache.py
+++ b/tests/test_engine_cache.py
@@ -1,9 +1,10 @@
-"""Unit tests for GPU-architecture keying of the cached TRT engine.
+"""Unit tests for hardware/TensorRT keying of the cached TRT engine.
 
-TensorRT engine plans are only valid on the compute capability they were built
-on, so the arch tag is part of the cache filename and a plan that still fails to
-deserialize is discarded and rebuilt once. These tests mock the CUDA capability
-query and the builder, so they run on CPU-only CI runners (no real GPU needed).
+TensorRT engine plans are only valid on the compute capability *and* the
+TensorRT major version they were built on, so both are part of the cache
+filename, and a plan that still fails to deserialize is discarded and rebuilt
+once. These tests mock the CUDA capability query, the TensorRT version, and the
+builder, so they run on CPU-only CI runners (no real GPU needed).
 """
 
 from pathlib import Path
@@ -11,7 +12,11 @@ from unittest.mock import patch
 
 import pytest
 
-from whisper_trt import IncompatibleEngineError, get_device_arch_tag
+from whisper_trt import (
+    IncompatibleEngineError,
+    get_device_arch_tag,
+    get_trt_version_tag,
+)
 from whisper_trt.model import get_model_filename, load_trt_model
 
 
@@ -28,6 +33,25 @@ def _cuda_available(available: bool):
         "whisper_trt.model.torch.cuda.is_available",
         return_value=available,
     )
+
+
+def _trt_version(version: str):
+    """Patch the reported TensorRT version string."""
+    return patch("whisper_trt.model.tensorrt.__version__", version)
+
+
+class TestTrtVersionTag:
+    """``get_trt_version_tag`` keys the cache on the TensorRT major version."""
+
+    def test_reports_the_major_version(self) -> None:
+        with _trt_version("11.2.1.2"):
+            assert get_trt_version_tag() == "trt11"
+
+    def test_minor_upgrades_share_a_tag(self) -> None:
+        with _trt_version("11.0.0.114"):
+            first = get_trt_version_tag()
+        with _trt_version("11.2.1.2"):
+            assert get_trt_version_tag() == first
 
 
 class TestDeviceArchTag:
@@ -55,14 +79,25 @@ class TestDeviceArchTag:
 class TestArchKeyedFilename:
     """The cache filename separates plans built on different architectures."""
 
-    def test_filename_carries_the_arch_tag(self) -> None:
-        with _cuda_available(True), _capability(8, 6):
+    def test_filename_carries_the_arch_and_trt_tags(self) -> None:
+        with _cuda_available(True), _capability(8, 6), _trt_version("11.2.1.2"):
             assert (
                 get_model_filename(
                     "base.en", "float16", decoder_mode="kv", max_workspace_mb=1024
                 )
-                == "base_en_trt_float16_kv4_ws1024_sm86.pth"
+                == "base_en_trt_float16_kv4_ws1024_sm86_trt11.pth"
             )
+
+    def test_different_trt_majors_never_share_a_filename(self) -> None:
+        """A TensorRT 10 plan must not be handed to TensorRT 11, which cannot load it."""
+        args = ("base.en", "float16")
+        kwargs = {"decoder_mode": "kv", "max_workspace_mb": 1024}
+        with _cuda_available(True), _capability(8, 6):
+            with _trt_version("10.16.1.11"):
+                on_trt10 = get_model_filename(*args, **kwargs)
+            with _trt_version("11.2.1.2"):
+                on_trt11 = get_model_filename(*args, **kwargs)
+        assert on_trt10 != on_trt11
 
     def test_different_archs_never_share_a_filename(self) -> None:
         """The regression: an sm_86 plan must not be picked up on an sm_89 GPU."""

--- a/tests/test_quant.py
+++ b/tests/test_quant.py
@@ -1,19 +1,54 @@
 """Unit tests for the explicit INT8 (Q/DQ) quantization of the audio encoder.
 
 TensorRT 11 only honours INT8 that is already in the graph, so what matters is
-that calibration produces a module whose ONNX export carries
-QuantizeLinear/DequantizeLinear pairs. That is checkable on CPU — no GPU, no
-TensorRT, no engine build — which is what these tests do.
+that the rewritten graph carries Q/DQ pairs, keeps FP32 I/O, and is *valid* —
+type inference included, since a graph whose QuantizeLinear scale no longer
+matches its input type passes a shallow check and then fails to parse. All of
+that is checkable on CPU: no GPU, no TensorRT, no engine build.
+
+These exercise the same ModelOpt entry points torch2trt calls during conversion
+(``torch2trt/precision.py``), because that is where the encoder's precision is
+decided.
 """
 
 import collections
+import importlib
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
 
+import numpy as np
 import onnx
 import pytest
 import torch
 from torch import nn
 
-from whisper_trt._quant import int8_available, quantize_encoder_int8
+from whisper_trt._quant import int8_available
+
+_T2T_DIR = Path(__file__).resolve().parent.parent / "torch2trt" / "torch2trt"
+
+
+def _t2t(name: str) -> ModuleType:
+    """Import a torch2trt module, falling back to the submodule checkout.
+
+    ``script/setup`` installs torch2trt, but these tests need to run without a
+    compiled install too (no CUDA toolkit on a CPU-only checkout), and both
+    modules used here import nothing from torch2trt itself.
+    """
+    try:
+        return importlib.import_module(f"torch2trt.{name}")
+    except ImportError:
+        pass
+    key = f"_torch2trt_checkout_{name}"
+    if key not in sys.modules:
+        spec = importlib.util.spec_from_file_location(key, _T2T_DIR / f"{name}.py")
+        assert spec is not None and spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[key] = module
+        spec.loader.exec_module(module)
+    return sys.modules[key]
+
 
 pytestmark = pytest.mark.skipif(
     not int8_available(), reason="nvidia-modelopt is not installed"
@@ -29,7 +64,7 @@ class _MiniEncoder(nn.Module):
 
     def __init__(self, seed: int = 0) -> None:
         super().__init__()
-        torch.manual_seed(seed)  # deterministic weights, for the accuracy check
+        torch.manual_seed(seed)
         self.conv = nn.Conv1d(_N_MELS, _N_STATE, 3, padding=1)
         self.gelu = nn.GELU()
         self.proj = nn.Linear(_N_STATE, _N_STATE)
@@ -44,12 +79,8 @@ class _MiniEncoder(nn.Module):
         return self.ln(self.proj(x))
 
 
-def _calibration_set(n: int = 3, seed: int = 0) -> list[list[torch.Tensor]]:
-    """Stand-in for the mel calibration set: the module's positional arguments.
-
-    Seeded, because quantization error depends on the data the ranges were
-    calibrated from and a drifting fixture makes the accuracy check flaky.
-    """
+def _calibration_set(n: int = 4, seed: int = 0) -> list[list[torch.Tensor]]:
+    """Stand-in for the mel calibration set: the module's positional arguments."""
     generator = torch.Generator().manual_seed(seed)
     pos = torch.randn(_N_FRAMES, _N_STATE, generator=generator)
     return [
@@ -57,61 +88,106 @@ def _calibration_set(n: int = 3, seed: int = 0) -> list[list[torch.Tensor]]:
     ]
 
 
-def _export_op_counts(module: nn.Module, tmp_path) -> collections.Counter:
-    """Export ``module`` through the same exporter torch2trt uses and count ops."""
-    path = tmp_path / "model.onnx"
-    inputs = _calibration_set(1)[0]
+_INPUT_NAMES = ["x", "positional_embedding"]
+
+
+def _export(module: nn.Module, path) -> str:
+    """Export through the exporter and options torch2trt uses."""
     torch.onnx.export(
         module,
-        tuple(inputs),
+        tuple(_calibration_set(1)[0]),
         str(path),
-        input_names=["x", "positional_embedding"],
+        input_names=_INPUT_NAMES,
         output_names=["output"],
         dynamic_axes={"x": {2: "frames"}},
-        # torch2trt forces the TorchScript exporter on torch >= 2.9, and it is
-        # the only one ModelOpt's quantizers emit Q/DQ through.
         dynamo=False,
     )
-    return collections.Counter(n.op_type for n in onnx.load(str(path)).graph.node)
+    return str(path)
 
 
-class TestQuantizeEncoderInt8:
-    """Calibration turns the module into one that exports Q/DQ."""
+def _ops(model: onnx.ModelProto) -> collections.Counter:
+    return collections.Counter(node.op_type for node in model.graph.node)
 
-    def test_export_carries_qdq_pairs(self, tmp_path) -> None:
-        module = _MiniEncoder().eval()
-        assert "QuantizeLinear" not in _export_op_counts(module, tmp_path)
 
-        quantized = quantize_encoder_int8(module, _calibration_set())
-        ops = _export_op_counts(quantized, tmp_path)
-        # Both the conv and the projection contribute weight and activation
+def _elem_types(model: onnx.ModelProto) -> set[int]:
+    return {
+        vi.type.tensor_type.elem_type
+        for vi in list(model.graph.input) + list(model.graph.output)
+    }
+
+
+def _quantize(src: str, dst: str, fp16: bool) -> onnx.ModelProto:
+    """Run the ONNX INT8 rewrite exactly as torch2trt does."""
+    precision = _t2t("precision")
+    calibration = _calibration_set()
+    flattener = _t2t("flattener").Flattener.from_value(calibration[0])
+    arrays = precision.calibration_arrays(calibration, flattener, _INPUT_NAMES)
+    # Each input is stacked the same number of times, which is how ModelOpt's
+    # data reader recovers the iteration count.
+    assert arrays["x"].shape[0] // 1 == len(calibration)
+    assert arrays["positional_embedding"].shape[0] // _N_FRAMES == len(calibration)
+    precision.quantize_onnx_int8(src, dst, arrays, fp16=fp16)
+    return onnx.load(dst)
+
+
+class TestOnnxInt8Quantization:
+    """The rewritten graph is INT8, optionally FP16, and valid."""
+
+    def test_inserts_qdq_pairs(self, tmp_path) -> None:
+        src = _export(_MiniEncoder().eval(), tmp_path / "model.onnx")
+        assert "QuantizeLinear" not in _ops(onnx.load(src))
+
+        ops = _ops(_quantize(src, str(tmp_path / "int8.onnx"), fp16=True))
+        # The conv and the projection each contribute weight and activation
         # quantizers, and every Quantize is paired with a Dequantize.
         assert ops["QuantizeLinear"] >= 4
         assert ops["QuantizeLinear"] == ops["DequantizeLinear"]
 
-    def test_quantizes_in_place(self) -> None:
-        module = _MiniEncoder().eval()
-        assert quantize_encoder_int8(module, _calibration_set()) is module
+    def test_int8_with_fp16_is_a_valid_graph(self, tmp_path) -> None:
+        """The regression: casting a Q/DQ graph with AutoCast produced a
+        QuantizeLinear whose scale type no longer matched its input, which only
+        strict type inference catches."""
+        src = _export(_MiniEncoder().eval(), tmp_path / "model.onnx")
+        model = _quantize(src, str(tmp_path / "int8.onnx"), fp16=True)
+        onnx.checker.check_model(model, full_check=True)
 
-    def test_calibrated_output_stays_close(self) -> None:
-        """Q/DQ costs accuracy, but INT8 over a calibrated range stays close.
+    def test_int8_without_fp16_is_a_valid_graph(self, tmp_path) -> None:
+        src = _export(_MiniEncoder().eval(), tmp_path / "model.onnx")
+        model = _quantize(src, str(tmp_path / "int8.onnx"), fp16=False)
+        onnx.checker.check_model(model, full_check=True)
 
-        Compared against the output's own spread rather than an absolute
-        tolerance: what matters is that quantization error is small relative to
-        the signal, not that it is below some fixed epsilon.
-        """
-        module = _MiniEncoder().eval()
-        calibration = _calibration_set()
-        inputs = calibration[0]
-        with torch.no_grad():
-            reference = module(*inputs)
-        quantize_encoder_int8(module, calibration)
-        with torch.no_grad():
-            quantized = module(*inputs)
-        error = (quantized - reference).abs().mean().item()
-        assert error < 0.1 * reference.std().item()
+    def test_graph_io_stays_fp32(self, tmp_path) -> None:
+        """The runtime keeps feeding mels and reading features as FP32."""
+        src = _export(_MiniEncoder().eval(), tmp_path / "model.onnx")
+        model = _quantize(src, str(tmp_path / "int8.onnx"), fp16=True)
+        assert _elem_types(model) == {onnx.TensorProto.FLOAT}
 
-    def test_empty_calibration_set_is_rejected(self) -> None:
-        """Without calibration data the quantizers have no ranges to export."""
-        with pytest.raises(RuntimeError, match="calibration set is empty"):
-            quantize_encoder_int8(_MiniEncoder().eval(), [])
+    def test_fp16_only_path_is_a_valid_graph(self, tmp_path) -> None:
+        """float16 (the default compute type) goes through AutoCast instead."""
+        src = _export(_MiniEncoder().eval(), tmp_path / "model.onnx")
+        model = _t2t("precision").autocast_onnx_to_fp16(onnx.load(src))
+        onnx.checker.check_model(model, full_check=True)
+        assert _ops(model)["Cast"] > 0
+        assert _elem_types(model) == {onnx.TensorProto.FLOAT}
+
+
+class TestCalibrationArrays:
+    """Calibration data is handed over in the layout ModelOpt expects."""
+
+    def test_rejects_a_mismatched_item(self) -> None:
+        calibration = _calibration_set(1)
+        flattener = _t2t("flattener").Flattener.from_value(calibration[0])
+        with pytest.raises(ValueError, match="takes 3 inputs"):
+            _t2t("precision").calibration_arrays(
+                calibration, flattener, [*_INPUT_NAMES, "extra"]
+            )
+
+    def test_concatenates_along_the_batch_axis(self) -> None:
+        calibration = _calibration_set(3)
+        flattener = _t2t("flattener").Flattener.from_value(calibration[0])
+        arrays = _t2t("precision").calibration_arrays(
+            calibration, flattener, _INPUT_NAMES
+        )
+        assert arrays["x"].shape == (3, _N_MELS, _N_FRAMES)
+        assert arrays["positional_embedding"].shape == (3 * _N_FRAMES, _N_STATE)
+        assert arrays["x"].dtype == np.float32

--- a/tests/test_quant.py
+++ b/tests/test_quant.py
@@ -1,0 +1,117 @@
+"""Unit tests for the explicit INT8 (Q/DQ) quantization of the audio encoder.
+
+TensorRT 11 only honours INT8 that is already in the graph, so what matters is
+that calibration produces a module whose ONNX export carries
+QuantizeLinear/DequantizeLinear pairs. That is checkable on CPU — no GPU, no
+TensorRT, no engine build — which is what these tests do.
+"""
+
+import collections
+
+import onnx
+import pytest
+import torch
+from torch import nn
+
+from whisper_trt._quant import int8_available, quantize_encoder_int8
+
+pytestmark = pytest.mark.skipif(
+    not int8_available(), reason="nvidia-modelopt is not installed"
+)
+
+_N_MELS = 8
+_N_STATE = 16
+_N_FRAMES = 20
+
+
+class _MiniEncoder(nn.Module):
+    """The encoder's quantizable shapes (conv front end + projection) in miniature."""
+
+    def __init__(self, seed: int = 0) -> None:
+        super().__init__()
+        torch.manual_seed(seed)  # deterministic weights, for the accuracy check
+        self.conv = nn.Conv1d(_N_MELS, _N_STATE, 3, padding=1)
+        self.gelu = nn.GELU()
+        self.proj = nn.Linear(_N_STATE, _N_STATE)
+        self.ln = nn.LayerNorm(_N_STATE)
+
+    def forward(
+        self, x: torch.Tensor, positional_embedding: torch.Tensor
+    ) -> torch.Tensor:
+        x = self.gelu(self.conv(x))
+        x = x.permute(0, 2, 1)
+        x = x + positional_embedding
+        return self.ln(self.proj(x))
+
+
+def _calibration_set(n: int = 3, seed: int = 0) -> list[list[torch.Tensor]]:
+    """Stand-in for the mel calibration set: the module's positional arguments.
+
+    Seeded, because quantization error depends on the data the ranges were
+    calibrated from and a drifting fixture makes the accuracy check flaky.
+    """
+    generator = torch.Generator().manual_seed(seed)
+    pos = torch.randn(_N_FRAMES, _N_STATE, generator=generator)
+    return [
+        [torch.randn(1, _N_MELS, _N_FRAMES, generator=generator), pos] for _ in range(n)
+    ]
+
+
+def _export_op_counts(module: nn.Module, tmp_path) -> collections.Counter:
+    """Export ``module`` through the same exporter torch2trt uses and count ops."""
+    path = tmp_path / "model.onnx"
+    inputs = _calibration_set(1)[0]
+    torch.onnx.export(
+        module,
+        tuple(inputs),
+        str(path),
+        input_names=["x", "positional_embedding"],
+        output_names=["output"],
+        dynamic_axes={"x": {2: "frames"}},
+        # torch2trt forces the TorchScript exporter on torch >= 2.9, and it is
+        # the only one ModelOpt's quantizers emit Q/DQ through.
+        dynamo=False,
+    )
+    return collections.Counter(n.op_type for n in onnx.load(str(path)).graph.node)
+
+
+class TestQuantizeEncoderInt8:
+    """Calibration turns the module into one that exports Q/DQ."""
+
+    def test_export_carries_qdq_pairs(self, tmp_path) -> None:
+        module = _MiniEncoder().eval()
+        assert "QuantizeLinear" not in _export_op_counts(module, tmp_path)
+
+        quantized = quantize_encoder_int8(module, _calibration_set())
+        ops = _export_op_counts(quantized, tmp_path)
+        # Both the conv and the projection contribute weight and activation
+        # quantizers, and every Quantize is paired with a Dequantize.
+        assert ops["QuantizeLinear"] >= 4
+        assert ops["QuantizeLinear"] == ops["DequantizeLinear"]
+
+    def test_quantizes_in_place(self) -> None:
+        module = _MiniEncoder().eval()
+        assert quantize_encoder_int8(module, _calibration_set()) is module
+
+    def test_calibrated_output_stays_close(self) -> None:
+        """Q/DQ costs accuracy, but INT8 over a calibrated range stays close.
+
+        Compared against the output's own spread rather than an absolute
+        tolerance: what matters is that quantization error is small relative to
+        the signal, not that it is below some fixed epsilon.
+        """
+        module = _MiniEncoder().eval()
+        calibration = _calibration_set()
+        inputs = calibration[0]
+        with torch.no_grad():
+            reference = module(*inputs)
+        quantize_encoder_int8(module, calibration)
+        with torch.no_grad():
+            quantized = module(*inputs)
+        error = (quantized - reference).abs().mean().item()
+        assert error < 0.1 * reference.std().item()
+
+    def test_empty_calibration_set_is_rejected(self) -> None:
+        """Without calibration data the quantizers have no ranges to export."""
+        with pytest.raises(RuntimeError, match="calibration set is empty"):
+            quantize_encoder_int8(_MiniEncoder().eval(), [])

--- a/tests/test_quant.py
+++ b/tests/test_quant.py
@@ -134,6 +134,7 @@ class TestOnnxInt8Quantization:
     """The rewritten graph is INT8, optionally FP16, and valid."""
 
     def test_inserts_qdq_pairs(self, tmp_path) -> None:
+        """The rewrite is what puts INT8 in the graph; the export has none."""
         src = _export(_MiniEncoder().eval(), tmp_path / "model.onnx")
         assert "QuantizeLinear" not in _ops(onnx.load(src))
 
@@ -152,6 +153,7 @@ class TestOnnxInt8Quantization:
         onnx.checker.check_model(model, full_check=True)
 
     def test_int8_without_fp16_is_a_valid_graph(self, tmp_path) -> None:
+        """INT8 alone (float32 elsewhere) has to hold up the same way."""
         src = _export(_MiniEncoder().eval(), tmp_path / "model.onnx")
         model = _quantize(src, str(tmp_path / "int8.onnx"), fp16=False)
         onnx.checker.check_model(model, full_check=True)
@@ -175,6 +177,8 @@ class TestCalibrationArrays:
     """Calibration data is handed over in the layout ModelOpt expects."""
 
     def test_rejects_a_mismatched_item(self) -> None:
+        """A calibration item that does not match the model's inputs is caught
+        here rather than as an opaque failure inside the quantizer."""
         calibration = _calibration_set(1)
         flattener = _t2t("flattener").Flattener.from_value(calibration[0])
         with pytest.raises(ValueError, match="takes 3 inputs"):
@@ -183,6 +187,8 @@ class TestCalibrationArrays:
             )
 
     def test_concatenates_along_the_batch_axis(self) -> None:
+        """Every input is stacked the same number of times, which is how the
+        data reader derives its iteration count."""
         calibration = _calibration_set(3)
         flattener = _t2t("flattener").Flattener.from_value(calibration[0])
         arrays = _t2t("precision").calibration_arrays(

--- a/tests/test_wyoming_whisper_trt.py
+++ b/tests/test_wyoming_whisper_trt.py
@@ -39,7 +39,7 @@ _SAMPLES_PER_CHUNK = 1024
 _STARTUP_TIMEOUT = 600
 _TRANSCRIBE_TIMEOUT = 120
 
-_INT8_WARNING_FRAGMENT = "int8 requests TensorRT implicit INT8"
+_INT8_WARNING_FRAGMENT = "int8 quantizes the encoder's convolutions"
 
 
 def _free_port() -> int:
@@ -262,7 +262,7 @@ async def test_wyoming_whisper_trt(compute_type: str, decoder_mode: str) -> None
         await asyncio.gather(*drains)
 
     if compute_type == "int8":
-        # The int8 no-op warning added after benchmarking must be present.
+        # int8 trades accuracy for speed, so the accuracy warning must be present.
         assert _INT8_WARNING_FRAGMENT in stderr_buf.decode(errors="replace"), (
-            "Expected the int8 reality-check warning in server logs"
+            "Expected the int8 accuracy warning in server logs"
         )

--- a/whisper_trt/__init__.py
+++ b/whisper_trt/__init__.py
@@ -22,6 +22,7 @@
 """Public API for the whisper_trt package."""
 
 from .__version__ import __version__
+from ._quant import int8_available
 from .cache import get_cache_dir, set_cache_dir
 from .model import (
     LARGE_MODELS,
@@ -32,6 +33,7 @@ from .model import (
     auto_workspace_mb,
     get_device_arch_tag,
     get_model_filename,
+    get_trt_version_tag,
     load_trt_model,
 )
 
@@ -46,6 +48,8 @@ __all__ = [
     "get_cache_dir",
     "get_device_arch_tag",
     "get_model_filename",
+    "get_trt_version_tag",
+    "int8_available",
     "load_trt_model",
     "set_cache_dir",
 ]

--- a/whisper_trt/_quant.py
+++ b/whisper_trt/_quant.py
@@ -1,111 +1,44 @@
 # SPDX-License-Identifier: MIT
 
-"""Explicit INT8 (Q/DQ) quantization of the audio encoder.
+"""Availability check for the explicit INT8 (Q/DQ) encoder path.
 
 TensorRT 11 removed implicit quantization: there is no calibrator to hand the
 builder any more, and INT8 is no longer something the builder may pick where it
-happens to be faster. Quantization now has to be *in the graph* as
-Quantize/Dequantize pairs, which also removes the old failure mode where an
-int8 build came out byte-for-byte identical to float16 because no INT8 tactic
-won on timing.
+happens to be faster. Quantization has to be *in the graph* as
+Quantize/Dequantize pairs, which also removes the old failure mode where an int8
+build came out byte-for-byte identical to float16 because no INT8 tactic won on
+timing.
 
-The flow is:
+The rewrite itself lives in torch2trt, which owns the ONNX export: after export
+it runs NVIDIA ModelOpt's ONNX quantizer over the graph, calibrating activation
+ranges on the mels ``model.py`` passes as ``int8_calib_dataset`` and casting
+whatever stays unquantized (attention matmuls, norms, softmax) to FP16 in the
+same pass. Doing both in one pass is required rather than incidental: ModelOpt's
+AutoCast, which handles the FP16-only case, does not support graphs that already
+carry Q/DQ.
 
-1. :func:`quantize_encoder_int8` swaps the encoder's ``Conv1d``/``Linear``
-   layers for ModelOpt quantized equivalents and calibrates their activation
-   ranges on real speech mels (per-channel INT8 weights, per-tensor INT8
-   activations, ``max`` calibration).
-2. torch2trt exports that module through the TorchScript ONNX exporter, where
-   ModelOpt's quantizers emit ``QuantizeLinear``/``DequantizeLinear`` nodes.
-3. TensorRT parses the Q/DQ graph and builds genuine INT8 kernels; everything
-   left unquantized (attention matmuls, layer norms, softmax) rides the FP16
-   cast that ``fp16_mode`` applies to the same graph.
-
-Attention matmuls and norms are deliberately left alone — quantizing them needs
-per-tensor ranges for intermediate activations that this calibration set does
-not represent, and they are not where the encoder's FLOPs are.
+This module only answers whether that path can run here, so the server can say
+so at startup instead of failing deep inside a build.
 """
 
-import copy
+import importlib
 import logging
-import time
-from typing import Any
-
-from torch import nn
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
 
 _INSTALL_HINT = (
-    "INT8 needs explicit Q/DQ quantization, which is provided by NVIDIA ModelOpt "
-    "('nvidia-modelopt' in requirements.txt). Install it, or build with "
-    "COMPUTE_TYPE=float16."
+    "INT8 needs explicit Q/DQ quantization of the ONNX graph, which is provided by "
+    "NVIDIA ModelOpt ('nvidia-modelopt' in requirements.txt). Install it, or build "
+    "with COMPUTE_TYPE=float16."
 )
-
-
-def _load_mtq() -> Any:
-    """Import ModelOpt's torch quantization API, or explain why int8 can't run."""
-    try:
-        import modelopt.torch.quantization as mtq
-    except ImportError as exc:
-        raise RuntimeError(f"{_INSTALL_HINT} (import failed: {exc})") from exc
-    return mtq
 
 
 def int8_available() -> bool:
     """Whether an INT8 encoder can be built in this environment."""
     try:
-        _load_mtq()
-    except RuntimeError:
+        importlib.import_module("modelopt.onnx.quantization")
+    except ImportError as exc:
+        logger.debug("INT8 unavailable: %s. %s", exc, _INSTALL_HINT)
         return False
     return True
-
-
-def quantize_encoder_int8(
-    module: nn.Module,
-    calib_dataset: list[list[Any]],
-    *,
-    verbose: bool = False,
-) -> nn.Module:
-    """Insert and calibrate INT8 Q/DQ observers in ``module``.
-
-    Args:
-        module: The audio-encoder module about to be converted to TensorRT.
-            Quantized in place; the same object is returned.
-        calib_dataset: Calibration items, each the module's positional arguments
-            (``[mel, positional_embedding]``). Every item is run once, so the
-            observers see the real activation ranges of real speech.
-        verbose: Log ModelOpt's per-layer quantization summary.
-
-    Returns:
-        nn.Module: The quantized module, ready for ONNX export with Q/DQ.
-
-    Raises:
-        RuntimeError: If ModelOpt is unavailable or calibration has nothing to
-            calibrate on.
-    """
-    if not calib_dataset:
-        raise RuntimeError(
-            "INT8 calibration set is empty; cannot quantize the encoder."
-        )
-
-    mtq = _load_mtq()
-    # INT8_DEFAULT_CFG is ModelOpt's CNN/vision recipe: per-channel (axis 0)
-    # INT8 weights, per-tensor INT8 inputs, "max" calibration. Copied because
-    # mtq.quantize() resolves the config in place.
-    config = copy.deepcopy(mtq.INT8_DEFAULT_CFG)
-
-    def forward_loop(model: nn.Module) -> None:
-        for item in calib_dataset:
-            model(*item)
-
-    logger.info(
-        "Calibrating INT8 quantizers for the audio encoder on %d clips",
-        len(calib_dataset),
-    )
-    started = time.monotonic()
-    quantized = mtq.quantize(module, config, forward_loop=forward_loop)
-    logger.info("INT8 calibration finished in %.1f s", time.monotonic() - started)
-    if verbose:
-        mtq.print_quant_summary(quantized)
-    return quantized

--- a/whisper_trt/_quant.py
+++ b/whisper_trt/_quant.py
@@ -1,0 +1,111 @@
+# SPDX-License-Identifier: MIT
+
+"""Explicit INT8 (Q/DQ) quantization of the audio encoder.
+
+TensorRT 11 removed implicit quantization: there is no calibrator to hand the
+builder any more, and INT8 is no longer something the builder may pick where it
+happens to be faster. Quantization now has to be *in the graph* as
+Quantize/Dequantize pairs, which also removes the old failure mode where an
+int8 build came out byte-for-byte identical to float16 because no INT8 tactic
+won on timing.
+
+The flow is:
+
+1. :func:`quantize_encoder_int8` swaps the encoder's ``Conv1d``/``Linear``
+   layers for ModelOpt quantized equivalents and calibrates their activation
+   ranges on real speech mels (per-channel INT8 weights, per-tensor INT8
+   activations, ``max`` calibration).
+2. torch2trt exports that module through the TorchScript ONNX exporter, where
+   ModelOpt's quantizers emit ``QuantizeLinear``/``DequantizeLinear`` nodes.
+3. TensorRT parses the Q/DQ graph and builds genuine INT8 kernels; everything
+   left unquantized (attention matmuls, layer norms, softmax) rides the FP16
+   cast that ``fp16_mode`` applies to the same graph.
+
+Attention matmuls and norms are deliberately left alone — quantizing them needs
+per-tensor ranges for intermediate activations that this calibration set does
+not represent, and they are not where the encoder's FLOPs are.
+"""
+
+import copy
+import logging
+import time
+from typing import Any
+
+from torch import nn
+
+logger = logging.getLogger(__name__)
+logger.addHandler(logging.NullHandler())
+
+_INSTALL_HINT = (
+    "INT8 needs explicit Q/DQ quantization, which is provided by NVIDIA ModelOpt "
+    "('nvidia-modelopt' in requirements.txt). Install it, or build with "
+    "COMPUTE_TYPE=float16."
+)
+
+
+def _load_mtq() -> Any:
+    """Import ModelOpt's torch quantization API, or explain why int8 can't run."""
+    try:
+        import modelopt.torch.quantization as mtq
+    except ImportError as exc:
+        raise RuntimeError(f"{_INSTALL_HINT} (import failed: {exc})") from exc
+    return mtq
+
+
+def int8_available() -> bool:
+    """Whether an INT8 encoder can be built in this environment."""
+    try:
+        _load_mtq()
+    except RuntimeError:
+        return False
+    return True
+
+
+def quantize_encoder_int8(
+    module: nn.Module,
+    calib_dataset: list[list[Any]],
+    *,
+    verbose: bool = False,
+) -> nn.Module:
+    """Insert and calibrate INT8 Q/DQ observers in ``module``.
+
+    Args:
+        module: The audio-encoder module about to be converted to TensorRT.
+            Quantized in place; the same object is returned.
+        calib_dataset: Calibration items, each the module's positional arguments
+            (``[mel, positional_embedding]``). Every item is run once, so the
+            observers see the real activation ranges of real speech.
+        verbose: Log ModelOpt's per-layer quantization summary.
+
+    Returns:
+        nn.Module: The quantized module, ready for ONNX export with Q/DQ.
+
+    Raises:
+        RuntimeError: If ModelOpt is unavailable or calibration has nothing to
+            calibrate on.
+    """
+    if not calib_dataset:
+        raise RuntimeError(
+            "INT8 calibration set is empty; cannot quantize the encoder."
+        )
+
+    mtq = _load_mtq()
+    # INT8_DEFAULT_CFG is ModelOpt's CNN/vision recipe: per-channel (axis 0)
+    # INT8 weights, per-tensor INT8 inputs, "max" calibration. Copied because
+    # mtq.quantize() resolves the config in place.
+    config = copy.deepcopy(mtq.INT8_DEFAULT_CFG)
+
+    def forward_loop(model: nn.Module) -> None:
+        for item in calib_dataset:
+            model(*item)
+
+    logger.info(
+        "Calibrating INT8 quantizers for the audio encoder on %d clips",
+        len(calib_dataset),
+    )
+    started = time.monotonic()
+    quantized = mtq.quantize(module, config, forward_loop=forward_loop)
+    logger.info("INT8 calibration finished in %.1f s", time.monotonic() - started)
+    if verbose:
+        mtq.print_quant_summary(quantized)
+    return quantized

--- a/whisper_trt/model.py
+++ b/whisper_trt/model.py
@@ -32,6 +32,7 @@ import gc
 import importlib.resources
 import logging
 import os
+import re
 import time
 import wave
 from collections.abc import Callable
@@ -116,15 +117,15 @@ def get_device_arch_tag() -> str:
 
 
 def get_trt_version_tag() -> str:
-    """Return a cache tag for the TensorRT major version in use.
+    """Return a cache tag for the exact TensorRT version in use.
 
-    A serialized plan is only loadable by the TensorRT major version that built
-    it, and 11 changed how precision is expressed (strong typing, explicit
-    quantization) so its engines differ from a 10.x plan even for identical
-    settings. Keying the filename on the major version means a TensorRT upgrade
-    quietly builds a new engine instead of failing to deserialize the old one.
+    Engines are built without ``VERSION_COMPATIBLE``, so a plan is loadable only
+    by the TensorRT build that produced it — not merely the same major version.
+    The full version therefore goes in the filename, so any upgrade (including a
+    patch) quietly builds a new engine instead of failing to deserialize the old
+    one. Non-alphanumerics become underscores to keep the filename plain.
     """
-    return "trt" + str(tensorrt.__version__).split(".", maxsplit=1)[0]
+    return "trt" + re.sub(r"[^0-9A-Za-z]+", "_", str(tensorrt.__version__))
 
 
 def _load_engine_module(engine_state: dict[str, Any], what: str) -> Any:
@@ -1444,8 +1445,9 @@ def get_model_filename(
     serialized layout no longer matches the loader, the ``sm<cc>`` tag keeps
     a plan built on one compute capability from being loaded on another (TRT
     deserialize "incompatible device" error 6) even when several machines share
-    one cache directory, and the ``trt<major>`` tag does the same across
-    TensorRT major versions, whose plans are never interchangeable.
+    one cache directory, and the ``trt<version>`` tag does the same across
+    TensorRT builds, whose plans are only loadable by the exact version that
+    produced them.
 
     Args:
         name (str): The model name (e.g. "tiny", "base.en").
@@ -1457,8 +1459,8 @@ def get_model_filename(
 
     Returns:
         str: Filename with the quant mode, schema, workspace, GPU architecture,
-            and TensorRT major version embedded
-            (e.g. "tiny_trt_float16_kv4_ws1024_sm89_trt11.pth").
+            and TensorRT version embedded
+            (e.g. "tiny_trt_float16_kv4_ws1024_sm89_trt11_2_1_2.pth").
 
     Raises:
         RuntimeError: If ``name`` is not a recognised model name or if

--- a/whisper_trt/model.py
+++ b/whisper_trt/model.py
@@ -124,7 +124,7 @@ def get_trt_version_tag() -> str:
     settings. Keying the filename on the major version means a TensorRT upgrade
     quietly builds a new engine instead of failing to deserialize the old one.
     """
-    return "trt" + str(tensorrt.__version__).split(".")[0]
+    return "trt" + str(tensorrt.__version__).split(".", maxsplit=1)[0]
 
 
 def _load_engine_module(engine_state: dict[str, Any], what: str) -> Any:

--- a/whisper_trt/model.py
+++ b/whisper_trt/model.py
@@ -62,6 +62,7 @@ from ._decoder import (
     TextDecoderTRT,
     TextDecoderTRTKV,
 )
+from ._quant import quantize_encoder_int8
 from .cache import get_cache_dir, make_cache_dir
 
 logger = logging.getLogger(__name__)
@@ -113,6 +114,18 @@ def get_device_arch_tag() -> str:
         logger.debug("Could not query CUDA compute capability: %s", err)
         return "smunknown"
     return f"sm{major}{minor}"
+
+
+def get_trt_version_tag() -> str:
+    """Return a cache tag for the TensorRT major version in use.
+
+    A serialized plan is only loadable by the TensorRT major version that built
+    it, and 11 changed how precision is expressed (strong typing, explicit
+    quantization) so its engines differ from a 10.x plan even for identical
+    settings. Keying the filename on the major version means a TensorRT upgrade
+    quietly builds a new engine instead of failing to deserialize the old one.
+    """
+    return "trt" + str(tensorrt.__version__).split(".")[0]
 
 
 def _load_engine_module(engine_state: dict[str, Any], what: str) -> Any:
@@ -208,10 +221,10 @@ def _reclaim_memory() -> None:
 
 # Directory of bundled mono 16 kHz speech clips used to calibrate INT8
 # activation ranges for the audio encoder. Calibrating on real speech (rather
-# than the random trace inputs torch2trt falls back to) is what makes INT8
-# produce usable scales. Drop additional ``*.wav`` files in here to widen
-# acoustic coverage — the more diverse speakers / recording conditions, the
-# better the calibration. Clips must be mono, 16 kHz, 16-bit PCM.
+# than the random trace input) is what makes the Q/DQ scales usable. Drop
+# additional ``*.wav`` files in here to widen acoustic coverage — the more
+# diverse speakers / recording conditions, the better the calibration. Clips
+# must be mono, 16 kHz, 16-bit PCM.
 _CALIBRATION_DIR = "calibration"
 
 
@@ -831,11 +844,10 @@ class WhisperTRTBuilder:
         """Return the effective compute type based on builder configuration.
 
         Reconciles ``quant_mode`` and ``fp16_mode`` into a single canonical
-        string used to key on-disk engine filenames. Note that "int8" denotes
-        a *request* for an INT8-calibrated encoder (the decoder always stays
-        FP16); TensorRT implicit quantization is per-layer optional, so the
-        built engine may contain no INT8 layers at all — see
-        ``build_audio_encoder_engine``.
+        string used to key on-disk engine filenames. Note that "int8" describes
+        the encoder only — the decoder always stays FP16 — and that the encoder
+        is INT8 in its quantized layers (convolutions and projections) and FP16
+        elsewhere; see ``build_audio_encoder_engine``.
 
         Returns:
             str: "int8" when ``quant_mode == "int8"``;
@@ -1055,7 +1067,9 @@ class WhisperTRTBuilder:
         """Build and return a TensorRT audio encoder engine."""
         dims = cls._load_model_once()
         model_inst = load_model(cls.model).cuda().eval()
-        encoder_module = _AudioEncoderEngine(
+        # Typed as the base class because int8 mode swaps quantized layers in
+        # and hands back a plain module.
+        encoder_module: nn.Module = _AudioEncoderEngine(
             model_inst.encoder.conv1,
             model_inst.encoder.conv2,
             model_inst.encoder.blocks,
@@ -1071,32 +1085,32 @@ class WhisperTRTBuilder:
             positional_embedding = positional_embedding.cuda()
         positional_embedding = positional_embedding.detach()
         int8_mode = cls.quant_mode == "int8"
-        # Calibrate INT8 activation ranges on real speech mels rather than
-        # letting torch2trt fall back to the random trace inputs.
-        #
-        # Caveat (measured): this is TensorRT *implicit* quantization, which
-        # treats INT8 as optional per layer — TensorRT only picks an INT8
-        # tactic where it times faster than FP16. On TensorRT 10.16 / RTX
-        # 3050 with model 'base', every layer came out FP16 and the engine
-        # was identical to a float16 build (verify with script/layer_report).
-        # Implicit quantization is deprecated in TensorRT 10; guaranteed INT8
-        # would need explicit Q/DQ quantization, worthwhile only for
-        # medium/large encoders.
-        int8_calib_dataset = (
-            _encoder_int8_calib_dataset(dims.n_mels, n_frames, positional_embedding)
-            if int8_mode
-            else None
-        )
         # Trace through whisper's manual-attention path (not SDPA) for the
         # same reason as build_text_decoder_engine.
         _reclaim_memory()
         with disable_sdpa():
+            if int8_mode:
+                # Explicit quantization: the Q/DQ pairs (and the activation
+                # ranges behind them) are baked into the module here, so the
+                # exported ONNX graph — not a builder flag TensorRT may ignore
+                # — is what makes the engine INT8. Calibrating on real speech
+                # mels rather than the random trace input is what makes those
+                # ranges usable.
+                calib_dataset = _encoder_int8_calib_dataset(
+                    dims.n_mels, n_frames, positional_embedding
+                )
+                encoder_module = quantize_encoder_int8(
+                    encoder_module, calib_dataset, verbose=cls.verbose
+                )
+                # The mels are GB-scale on larger models; drop them before the
+                # build allocates its own buffers.
+                del calib_dataset
+                _reclaim_memory()
             return _torch2trt_convert(
                 encoder_module,
                 [x, positional_embedding],
                 use_onnx=True,
                 int8_mode=int8_mode,
-                int8_calib_dataset=int8_calib_dataset,
                 min_shapes=[(1, dims.n_mels, 1), (1, dims.n_audio_state)],
                 opt_shapes=[
                     (1, dims.n_mels, n_frames),
@@ -1109,9 +1123,9 @@ class WhisperTRTBuilder:
                 input_names=["x", "positional_embedding"],
                 output_names=["output"],
                 max_workspace_size=cls.max_workspace_size,
-                # Allow FP16 fallback alongside INT8 so TensorRT can keep
-                # precision-sensitive layers in FP16 (mixed precision) instead
-                # of forcing every layer to INT8.
+                # Everything the Q/DQ pairs don't cover (attention matmuls,
+                # layer norms, softmax) runs FP16 rather than FP32, so an int8
+                # encoder is INT8-where-quantized and FP16 elsewhere.
                 fp16_mode=cls.fp16_mode or int8_mode,
                 log_level=_trt_log_level(cls.verbose),
             )
@@ -1437,10 +1451,11 @@ def get_model_filename(
     simple), workspace budget, and GPU architecture produces a separate cached
     engine file, preventing silent reuse of an engine built under different
     settings. The engine-schema tag additionally invalidates caches whose
-    serialized layout no longer matches the loader, and the ``sm<cc>`` tag keeps
+    serialized layout no longer matches the loader, the ``sm<cc>`` tag keeps
     a plan built on one compute capability from being loaded on another (TRT
     deserialize "incompatible device" error 6) even when several machines share
-    one cache directory.
+    one cache directory, and the ``trt<major>`` tag does the same across
+    TensorRT major versions, whose plans are never interchangeable.
 
     Args:
         name (str): The model name (e.g. "tiny", "base.en").
@@ -1451,8 +1466,9 @@ def get_model_filename(
             defaults to the builder's current ``max_workspace_size`` converted to MiB.
 
     Returns:
-        str: Filename with the quant mode, schema, and workspace embedded
-            (e.g. "tiny_trt_float16_kv4_ws1024_sm89.pth").
+        str: Filename with the quant mode, schema, workspace, GPU architecture,
+            and TensorRT major version embedded
+            (e.g. "tiny_trt_float16_kv4_ws1024_sm89_trt11.pth").
 
     Raises:
         RuntimeError: If ``name`` is not a recognised model name or if
@@ -1473,7 +1489,10 @@ def get_model_filename(
     )
     base = MODEL_FILENAMES[name]
     stem, ext = os.path.splitext(base)
-    return f"{stem}_{quant_mode}_{schema}_ws{workspace_mb}_{get_device_arch_tag()}{ext}"
+    return (
+        f"{stem}_{quant_mode}_{schema}_ws{workspace_mb}"
+        f"_{get_device_arch_tag()}_{get_trt_version_tag()}{ext}"
+    )
 
 
 def load_trt_model(

--- a/whisper_trt/model.py
+++ b/whisper_trt/model.py
@@ -62,7 +62,6 @@ from ._decoder import (
     TextDecoderTRT,
     TextDecoderTRTKV,
 )
-from ._quant import quantize_encoder_int8
 from .cache import get_cache_dir, make_cache_dir
 
 logger = logging.getLogger(__name__)
@@ -1067,9 +1066,7 @@ class WhisperTRTBuilder:
         """Build and return a TensorRT audio encoder engine."""
         dims = cls._load_model_once()
         model_inst = load_model(cls.model).cuda().eval()
-        # Typed as the base class because int8 mode swaps quantized layers in
-        # and hands back a plain module.
-        encoder_module: nn.Module = _AudioEncoderEngine(
+        encoder_module = _AudioEncoderEngine(
             model_inst.encoder.conv1,
             model_inst.encoder.conv2,
             model_inst.encoder.blocks,
@@ -1088,29 +1085,22 @@ class WhisperTRTBuilder:
         # Trace through whisper's manual-attention path (not SDPA) for the
         # same reason as build_text_decoder_engine.
         _reclaim_memory()
+        # Explicit quantization: torch2trt rewrites the exported ONNX graph with
+        # Q/DQ pairs calibrated on these mels, so the graph — not a builder flag
+        # TensorRT is free to ignore — is what makes the engine INT8. Real speech
+        # rather than the random trace input is what makes the ranges usable.
+        int8_calib_dataset = (
+            _encoder_int8_calib_dataset(dims.n_mels, n_frames, positional_embedding)
+            if int8_mode
+            else None
+        )
         with disable_sdpa():
-            if int8_mode:
-                # Explicit quantization: the Q/DQ pairs (and the activation
-                # ranges behind them) are baked into the module here, so the
-                # exported ONNX graph — not a builder flag TensorRT may ignore
-                # — is what makes the engine INT8. Calibrating on real speech
-                # mels rather than the random trace input is what makes those
-                # ranges usable.
-                calib_dataset = _encoder_int8_calib_dataset(
-                    dims.n_mels, n_frames, positional_embedding
-                )
-                encoder_module = quantize_encoder_int8(
-                    encoder_module, calib_dataset, verbose=cls.verbose
-                )
-                # The mels are GB-scale on larger models; drop them before the
-                # build allocates its own buffers.
-                del calib_dataset
-                _reclaim_memory()
             return _torch2trt_convert(
                 encoder_module,
                 [x, positional_embedding],
                 use_onnx=True,
                 int8_mode=int8_mode,
+                int8_calib_dataset=int8_calib_dataset,
                 min_shapes=[(1, dims.n_mels, 1), (1, dims.n_audio_state)],
                 opt_shapes=[
                     (1, dims.n_mels, n_frames),
@@ -1124,8 +1114,8 @@ class WhisperTRTBuilder:
                 output_names=["output"],
                 max_workspace_size=cls.max_workspace_size,
                 # Everything the Q/DQ pairs don't cover (attention matmuls,
-                # layer norms, softmax) runs FP16 rather than FP32, so an int8
-                # encoder is INT8-where-quantized and FP16 elsewhere.
+                # layer norms, softmax) is cast to FP16 in the same quantizer
+                # pass, so an int8 encoder is INT8-where-quantized, FP16 else.
                 fp16_mode=cls.fp16_mode or int8_mode,
                 log_level=_trt_log_level(cls.verbose),
             )

--- a/wyoming_whisper_trt/__main__.py
+++ b/wyoming_whisper_trt/__main__.py
@@ -28,6 +28,7 @@ from whisper_trt import (
     WhisperTRTBuilder,
     auto_workspace_mb,
     get_model_filename,
+    int8_available,
     load_trt_model,
 )
 
@@ -226,19 +227,30 @@ async def run_server(
 def _apply_compute_type(compute_type: str) -> None:
     """Configure the builder for the requested compute type.
 
-    Warns when int8 is selected, since TensorRT is free to ignore the
-    request (implicit quantization is per-layer optional).
+    Warns when int8 is selected, since quantizing costs accuracy that only
+    measurement on the target hardware can quantify, and says so up front when
+    this environment cannot build an int8 engine at all.
     """
     WhisperTRTBuilder.quant_mode = compute_type
     WhisperTRTBuilder.fp16_mode = compute_type == "float16"
     if compute_type == "int8":
+        if not int8_available():
+            # Not fatal: an engine cached from an environment that *did* have
+            # ModelOpt still loads and runs. Only a build needs it.
+            logger.error(
+                "int8 was requested but NVIDIA ModelOpt is unavailable, so no INT8 "
+                "engine can be built here (this is expected on the iGPU/JetPack "
+                "image). Loading a cached int8 engine still works; otherwise use "
+                "COMPUTE_TYPE=float16."
+            )
         logger.warning(
-            "int8 requests TensorRT implicit INT8 quantization for the encoder "
-            "(the decoder always runs FP16), but TensorRT only uses INT8 where "
-            "it beats FP16. Measured on TensorRT 10 (RTX 3050, model 'base') "
-            "the result was identical to float16 — zero INT8 layers, same "
-            "accuracy and VRAM — with a slower engine build. Verify with "
-            "script/layer_report before assuming any benefit."
+            "int8 quantizes the encoder's convolutions and projections to INT8 "
+            "(explicit Q/DQ, calibrated on the bundled speech clips) and runs "
+            "everything else — attention, norms, and the whole decoder — in "
+            "FP16. Unlike float16 this trades accuracy for speed, and the "
+            "engine takes longer to build. Compare WER and latency with "
+            "script/benchmark, and check which layers actually came out INT8 "
+            "with script/layer_report, before running it in production."
         )
 
 


### PR DESCRIPTION
Migrates to TensorRT 11, which removes far more than the calibrator: **weak typing is gone entirely**. The per-precision builder flags (`BuilderFlag.FP16`, `INT8`, `STRICT_TYPES`), `ITensor.setType`, `ILayer.setPrecision`, and the whole `IInt8Calibrator` family were removed in 11.0 — every network is strongly typed, so precision has to be expressed in the ONNX graph handed to the parser. This affects the default `float16` path, not just `int8`.

Renovate's bare bump (`renovate/major-tensorrt`) crashed at import, before the server ever listened:

```
File ".../torch2trt/dataset_calibrator.py", line 15, in <module>
    DEFAULT_CALIBRATION_ALGORITHM = trt.CalibrationAlgoType.ENTROPY_CALIBRATION
AttributeError: module 'tensorrt' has no attribute 'CalibrationAlgoType'
```

Depends on Jonah-May-OSS/torch2trt#7 (merged); the submodule pointer here tracks it.

## What changed

- **`float16`** rides ModelOpt AutoCast in torch2trt, which casts the exported graph and keeps its I/O FP32 — the documented replacement for `BuilderFlag.FP16`.
- **`int8`** is now explicit Q/DQ. After the encoder is exported, ModelOpt's ONNX quantizer rewrites the graph with Q/DQ pairs calibrated on the bundled speech mels and casts the unquantized remainder to FP16 in the same pass. This also fixes the long-standing surprise documented in the README: on TensorRT 10 an int8 build could come out with *zero* INT8 layers, identical to float16, because no INT8 tactic won on timing. Q/DQ is honoured regardless of tactic timings.
- **Engine cache filenames gain a `trt<major>` tag.** Plans never survive a TensorRT major upgrade, so without it every cached checkpoint would raise `IncompatibleEngineError` instead of quietly rebuilding.
- **The iGPU/JetPack path drops ModelOpt** (it needs torch >= 2.8; JetPack ships 2.5), so that image still installs. `float16`/`float32` are unaffected there; `int8` reports why it cannot build.
- **New CPU-only tests** cover the quantized graph and the version tag — no GPU, no TensorRT, no engine build.

## Review notes

Two things reviewers should weigh, both flagged rather than buried:

1. **Image size grows ~210 MB.** `nvidia-modelopt` hard-depends on scipy (115 MB) and pulp (36 MB), plus four packages its ONNX subpackage imports eagerly but only declares under its heavyweight `[onnx]` extra (which would drag in cupy). Since FP16 needs AutoCast too, this is not confined to `int8`. Cuts against the recent image-trimming work.
2. **FP16 numerics changed.** AutoCast casts everything not in the block list, where the old flag let TensorRT pick per-layer by tactic timing. NVIDIA documents AutoCast as the `--fp16` equivalent, and no accuracy recipe was invented here — but `script/benchmark` should be re-run on **float16**, not only `int8`. `fp16_op_block_list` is plumbed through torch2trt as the escape hatch.

`int8` builds are also slower now: calibration replays the graph through onnxruntime, and the image ships CPU-only onnxruntime (~one CPU encoder pass per clip). `int8_calibration_eps` is plumbed through if a GPU provider is ever added.

## Testing

- `37 passed, 3 skipped` on CPU; pyright strict, ruff, and isort clean.
- The ONNX rewrites are verified with `onnx.checker.check_model(..., full_check=True)` — type inference included, which is what catches an invalid Q/DQ graph.
- **Not verified:** no engine was built. This machine has neither TensorRT 11 nor a GPU, so the TRT 11 code paths were exercised against a stubbed API surface. A `--force-rebuild` on the self-hosted runner across `float32`/`float16`/`int8` is the real proof.

Supersedes `renovate/major-tensorrt`, which should be closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added explicit INT8 encoder quantization with ModelOpt, including availability checks and calibration validation.
  * Added TensorRT version tagging to engine caches to prevent incompatible plan reuse.
  * Added public access to INT8 availability and TensorRT version information.

* **Bug Fixes**
  * Improved handling and messaging when INT8 tooling is unavailable.
  * Updated TensorRT compatibility to version 11.

* **Documentation**
  * Expanded INT8 setup, platform limitations, benchmarking, and accuracy guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->