### PR TITLE
fix(release): close the milestone by version, not branch name

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -71,4 +71,4 @@ jobs:
         with:
           token: ${{ secrets.PERSONAL_GITHUB_TOKEN }}
           repository: ${{ github.repository }}
-          milestone: ${{ github.ref_name }}
+          milestone: ${{ env.VERSION }}


### PR DESCRIPTION
The close step passed `github.ref_name`, which for a push to `release/1.2.3` is `release/1.2.3` -- the `release/` prefix intact. Milestones are named after the bare version (`1.2.3`, matching the tags), so GitReleaseManager looked up a milestone that never exists and failed the step after create and publish had already succeeded, leaving the release published but its milestone open.

Use `env.VERSION`, as the create and publish steps already do.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Release closing now correctly associates the release with its version milestone instead of the full branch reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->