### PR TITLE
fix(igpu): set NVIDIA_EMBEDDED in the published-image compose file

### DIFF
--- a/docker-compose-igpu.yaml
+++ b/docker-compose-igpu.yaml
@@ -16,5 +16,9 @@ services:
       DEBUG:      "${DEBUG:-false}"
       NVIDIA_VISIBLE_DEVICES:     all
       NVIDIA_DRIVER_CAPABILITIES: compute,utility
+      # Required on Jetson. run.sh keys its first-run setup off this: without it
+      # setup installs the x86 torch/TensorRT pins from requirements.txt over
+      # JetPack's own builds and the container fails to start.
+      NVIDIA_EMBEDDED: "true"
     network_mode: host
     runtime: nvidia


### PR DESCRIPTION
docker-compose-igpu.yaml pulls the published igpu image but never set NVIDIA_EMBEDDED, while the build-from-source docker-compose-github-igpu.yaml does. run.sh keys its first-run setup off that variable: without it the Jetson path is skipped, so setup neither strips the x86 torch/tensorrt pins from requirements.txt nor creates the venv with --system_site_packages. pip then tries to install torch==2.13.0 and the CUDA-13 tensorrt_cu13 wheels over JetPack's CUDA 12.6 stack in a python 3.10 venv, which is exactly the conflict run.sh documents.

The failure happens on container start rather than at build, so no CI job catches it.