### PR TITLE
fix(image): return the runtime stage to Ubuntu 24.04 / python3.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,8 +37,13 @@ RUN printf 'Acquire::Retries "3";\nAcquire::http::Timeout "30";\nAcquire::https:
 
 # ===========================================================================
 # Runtime stage: slim Ubuntu. This tag is NOT a free-floating dependency — it
-# must stay on the same Ubuntu release as the NGC builder above (26.04 /
-# python3.14). script/setup builds the venv with venv's POSIX default of
+# must stay on the same Ubuntu release as the NGC builder above.
+# nvcr.io/nvidia/tensorrt:26.07-py3 is Ubuntu 24.04 (CUDA 13.3.1, TRT
+# 11.1.0.106), so this is 24.04 and its python3.12. Ubuntu 26.04 was tried and
+# reverted: it has no python3.12 package, and installing its python3.14
+# instead left the venv interpreter unable to find its own stdlib
+# ("ModuleNotFoundError: No module named 'encodings'").
+# script/setup builds the venv with venv's POSIX default of
 # symlinks, so the .venv copied in below points at the builder's interpreter
 # path: a runtime without that exact python3.X gets a dangling symlink, and a
 # different minor version can't load the cp3XX wheels in site-packages either.
@@ -54,12 +59,12 @@ RUN printf 'Acquire::Retries "3";\nAcquire::http::Timeout "30";\nAcquire::https:
 # nvidia-smi are injected by the NVIDIA container runtime. This drops the
 # ~3.8 GB CUDA devel toolkit and the build toolchain from the image.
 # ===========================================================================
-FROM ubuntu:26.04 AS runtime
+FROM ubuntu:24.04 AS runtime
 
 RUN printf 'Acquire::Retries "3";\nAcquire::http::Timeout "30";\nAcquire::https::Timeout "30";\n' > /etc/apt/apt.conf.d/99network-resilience \
     && apt-get update && apt-get install -y --no-install-recommends \
         python3 \
-        python3.14 \
+        python3.12 \
         ffmpeg \
         libgomp1 \
         ca-certificates \
@@ -82,6 +87,8 @@ RUN set -eu; \
     py=/usr/src/wyoming-whisper-trt/.venv/bin/python3; \
     if ! "$py" -c 'import sys; print("venv python:", sys.version)'; then \
         echo "ERROR: the venv interpreter does not run on this runtime base." >&2; \
+        echo "It resolves to: $(readlink -f "$py" 2>/dev/null || echo '<dangling>')" >&2; \
+        echo "This runtime provides: $(ls -d /usr/lib/python3.* 2>/dev/null | tr '\n' ' ')" >&2; \
         echo "The runtime python minor version must match the NGC builder's." >&2; \
         exit 1; \
     fi; \


### PR DESCRIPTION
The move to ubuntu:26.04 + python3.14 does not work. The NGC builder, nvcr.io/nvidia/tensorrt:26.07-py3, is Ubuntu 24.04 (CUDA 13.3.1, TRT 11.1.0.106), so its venv is python3.12. Copied onto a python3.14 runtime the venv interpreter cannot find its own stdlib:

  Fatal Python error: init_fs_encoding: failed to get the Python codec of
  the filesystem encoding
  ModuleNotFoundError: No module named 'encodings'

Ubuntu 26.04 cannot host that venv at all: it has no python3.12 package, which is what the original build failure was about. Matching the builder means 24.04.

The build-time assertion added alongside the 26.04 change caught this in the runtime stage rather than shipping an image that dies on startup, so keep it, and have it print the interpreter's resolved target and the python versions the runtime actually provides — that is the pair of facts needed to diagnose the mismatch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime compatibility by aligning the application environment with the build environment.
  * Enhanced startup validation errors with clearer interpreter and Python installation details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->