### PR TITLE
fix(image): run the venv assertion from the application directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -84,6 +84,10 @@ COPY --from=builder /usr/src/wyoming-whisper-trt /usr/src/wyoming-whisper-trt
 # wheels, so a runtime whose python minor version differs from the builder's
 # produces an image that only fails when a container starts. Catch it here.
 RUN set -eu; \
+    # The app is not pip-installed into the venv (script/setup installs
+    # requirements + torch2trt only), so wyoming_whisper_trt resolves via the
+    # working directory, exactly as run.sh does before launching it.
+    cd /usr/src/wyoming-whisper-trt; \
     py=/usr/src/wyoming-whisper-trt/.venv/bin/python3; \
     if ! "$py" -c 'import sys; print("venv python:", sys.version)'; then \
         echo "ERROR: the venv interpreter does not run on this runtime base." >&2; \

--- a/Dockerfile.igpu
+++ b/Dockerfile.igpu
@@ -83,7 +83,11 @@ COPY --from=builder /usr/src/wyoming-whisper-trt /usr/src/wyoming-whisper-trt
 # venv resolves torch and tensorrt through the base image's site-packages, so
 # a base whose python minor version or CUDA stack does not match the venv
 # surfaces here instead of at container startup.
-RUN /usr/src/wyoming-whisper-trt/.venv/bin/python3 -c \
+# The app is not pip-installed into the venv (script/setup installs
+# requirements + torch2trt only), so wyoming_whisper_trt resolves via the
+# working directory, exactly as run.sh does before launching it.
+RUN cd /usr/src/wyoming-whisper-trt \
+    && ./.venv/bin/python3 -c \
         "import sys, torch, tensorrt, wyoming_whisper_trt; \
          print('python', sys.version.split()[0], '/ torch', torch.__version__, \
                '/ tensorrt', tensorrt.__version__)"


### PR DESCRIPTION
The assertion imported wyoming_whisper_trt with the working directory left at the base image's default (/ for ubuntu, /workspace for the NGC iGPU image). The app is never pip-installed into the venv — script/setup installs requirements.txt and torch2trt only — so the package resolves through the working directory, which is why run.sh cds to /usr/src/wyoming-whisper-trt before launching it. From / the import raises ModuleNotFoundError and fails the build.

The interpreter check passed and the diagnostics did not print, since the failure was in the import that follows, not in the guarded branch.

cd into the application directory first, in both Dockerfiles.