### PR TITLE
CI: route buildx image pulls through lab registry caches

### DIFF
--- a/.github/workflows/publish_container.yaml
+++ b/.github/workflows/publish_container.yaml
@@ -43,6 +43,23 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@21162887f0d6e25b4e8eafb0cf44cf9bf7f6acd3
+        with:
+          # Route image pulls through the lab's pull-through registry caches.
+          # LAN-only mirrors; buildkit falls back to the upstream registry if
+          # a mirror is unreachable (e.g. on a GitHub-hosted runner).
+          buildkitd-config-inline: |
+            [registry."docker.io"]
+              mirrors = ["192.168.7.45:5000"]
+            [registry."192.168.7.45:5000"]
+              http = true
+            [registry."ghcr.io"]
+              mirrors = ["192.168.7.45:5001"]
+            [registry."192.168.7.45:5001"]
+              http = true
+            [registry."nvcr.io"]
+              mirrors = ["192.168.7.45:5004"]
+            [registry."192.168.7.45:5004"]
+              http = true
 
       - name: Log in to Docker Hub
         uses: docker/login-action@ba754150c9dbbaa912ae0ac3cfba43f84195cef2


### PR DESCRIPTION
The cluster runs pull-through registry caches (docker.io/ghcr.io/nvcr.io on 192.168.7.45) and node containerd already uses them — but buildx builds inside the dind sidecar bypassed them entirely, re-downloading multi-GB NGC base images from the WAN on every run.

This adds `buildkitd-config-inline` mirrors to the buildx builder. Buildkit falls back to the upstream registry if a mirror is unreachable, so runs on GitHub-hosted runners are unaffected.

Expected effects: much faster image builds after first cache fill, and the recurring ~900 Mbps WAN pull bursts disappear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Infrastructure**
  * Improved container image build reliability by configuring registry mirrors with automatic upstream fallback.
  * Added support for faster access to Docker Hub, GHCR, and NGC images in supported environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->