### PR TITLE
fix(build): unblock FP16 engine builds for the large family

### DIFF
--- a/tests/test_quant.py
+++ b/tests/test_quant.py
@@ -50,6 +50,24 @@ def _t2t(name: str) -> ModuleType:
     return sys.modules[key]
 
 
+def _t2t_core() -> ModuleType:
+    """Import torch2trt's conversion module, falling back to the checkout.
+
+    Unlike the modules above this one is only importable as part of the
+    ``torch2trt`` package (its siblings import each other absolutely), and the
+    checkout's outer directory shadows that package name from the repo root. The
+    fallback puts the inner directory first on the path so the real package wins.
+    """
+    try:
+        return importlib.import_module("torch2trt.torch2trt")
+    except ImportError:
+        pass
+    sys.path.insert(0, str(_T2T_DIR.parent))
+    for name in [n for n in sys.modules if n == "torch2trt" or n.startswith("torch2trt.")]:
+        del sys.modules[name]
+    return importlib.import_module("torch2trt.torch2trt")
+
+
 pytestmark = pytest.mark.skipif(
     not int8_available(), reason="nvidia-modelopt is not installed"
 )
@@ -171,6 +189,65 @@ class TestOnnxInt8Quantization:
         onnx.checker.check_model(model, full_check=True)
         assert _ops(model)["Cast"] > 0
         assert _elem_types(model) == {onnx.TensorProto.FLOAT}
+
+
+class TestOversizedGraphFp16:
+    """FP16 on a graph whose weights have to spill into an external data file.
+
+    The large family's audio encoder is ~2.5 GB in FP32, over protobuf's 2 GiB
+    serialization limit, so it is saved with its weights in a sidecar next to the
+    model. That save rewrites the proto in place — the initializers come back as
+    a reference resolved relative to the model file — so the order the graph is
+    saved and cast in decides whether AutoCast gets a usable model. Forced on a
+    miniature graph here by lowering the size threshold; the real trigger needs
+    a 2 GB export.
+    """
+
+    @pytest.fixture
+    def core(self, monkeypatch):
+        """torch2trt's conversion module, with every graph counting as oversized."""
+        module = _t2t_core()
+        monkeypatch.setattr(module, "_PROTO_SIZE_LIMIT", 0)
+        monkeypatch.setattr(module, "_PROTO_SIZE_MARGIN", 0)
+        return module
+
+    def test_save_spends_the_proto(self, core, tmp_path) -> None:
+        """The mutation the ordering has to work around: after an external-data
+        save the proto no longer carries its weights, only a relative reference
+        that its consumer has to resolve from the model's directory."""
+        model = onnx.load(_export(_MiniEncoder().eval(), tmp_path / "model.onnx"))
+        assert core.save_onnx(onnx, model, str(tmp_path / "model_out.onnx")) is True
+
+        externalized = [
+            init
+            for init in model.graph.initializer
+            if init.data_location == onnx.TensorProto.EXTERNAL
+        ]
+        assert externalized
+        assert not any(init.raw_data for init in externalized)
+
+    def test_autocast_precedes_the_save(self, core, tmp_path, monkeypatch) -> None:
+        """The regression: torch2trt saved the graph before casting it, and
+        AutoCast's onnx.checker call resolves external data against the process
+        CWD rather than the model's directory, so it could not find the sidecar
+        ("... should be stored in model_out.onnx.data, but it is not regular
+        file"). Casting first hands AutoCast a graph that still has its weights.
+        """
+        src = _export(_MiniEncoder().eval(), tmp_path / "model.onnx")
+        out_dir = tmp_path / "build"
+        out_dir.mkdir()
+        elsewhere = tmp_path / "cwd"
+        elsewhere.mkdir()
+        monkeypatch.chdir(elsewhere)
+
+        model = _t2t("precision").autocast_onnx_to_fp16(onnx.load(src))
+        out_path = str(out_dir / "model_out.onnx")
+        assert core.save_onnx(onnx, model, out_path) is True
+
+        # Saved this way the graph is only parseable from its path, which is how
+        # torch2trt hands it to TensorRT's OnnxParser.
+        onnx.checker.check_model(out_path, full_check=True)
+        assert _ops(onnx.load(out_path))["Cast"] > 0
 
 
 class TestCalibrationArrays:

--- a/tests/test_quant.py
+++ b/tests/test_quant.py
@@ -63,7 +63,9 @@ def _t2t_core() -> ModuleType:
     except ImportError:
         pass
     sys.path.insert(0, str(_T2T_DIR.parent))
-    for name in [n for n in sys.modules if n == "torch2trt" or n.startswith("torch2trt.")]:
+    for name in [
+        n for n in sys.modules if n == "torch2trt" or n.startswith("torch2trt.")
+    ]:
         del sys.modules[name]
     return importlib.import_module("torch2trt.torch2trt")
 


### PR DESCRIPTION
Follow-on to #1016. That fix got the large family past the >2 GB ONNX export; this one gets it past the FP16 cast immediately after, so `large-v3-turbo` builds at the default `COMPUTE_TYPE=float16` instead of only at `float32`.

## Symptom

Reported on an RTX 5060 Ti 16GB (Unraid, driver 595.84, fresh `/data`, `MODEL=large-v3-turbo`) against v1.2.2. The protobuf `EncodeError` is gone, and the build now dies one step later, in the FP16 autocast:

```
Data of TensorProto (tensor name: onnx::Conv_4184) should be stored in model_out.onnx.data, but it is not regular file.
Exception: AutoCast can only operate on valid ONNX models ...
```

## Cause

`onnx.save(save_as_external_data=True)` rewrites the proto it is handed: `convert_model_to_external_data` strips each initializer's `raw_data` and replaces it with a reference relative to the model file. torch2trt saved the
graph *before* handing it to AutoCast, so ModelOpt received a proto carrying no weights, and its `onnx.checker.check_model` call resolves that reference against the process CWD rather than the model's directory — hence "is not regular file".

Only reachable on graphs over protobuf's 2 GiB limit, i.e. the large family's ~635M-param audio encoder (~2.5 GB in FP32), and only since #1016 made the external-data save happen at all. `float32` skips AutoCast entirely, which is why it already built.

## Fix

Submodule bump to Jonah-May-OSS/torch2trt#8, which runs AutoCast before the graph is written out. ModelOpt handles an oversized in-memory proto on its own — both `check_model` and `infer_shapes` spill to their own temp directory from a
deep copy — so it wants the weights inline. INT8 still runs after the save, since the quantizer takes a path. The FP16 path now writes the graph once instead of twice.

The same bump raises directly when `build_serialized_network()` returns `None`. It reports a failed build that way, having logged the cause through the TRT logger; unchecked it travelled as far as the first attribute access on the
engine and surfaced as `'NoneType' object has no attribute 'serialize'` from `state_dict()`. That is what a build OOM looked like when the GPU was shared with other containers (~13GB resident) — the OOM itself is expected there, only
the masking was a defect.

## Tests

Adds `TestOversizedGraphFp16` to `tests/test_quant.py`, forcing the external-data path on a miniature graph by lowering torch2trt's size threshold, so both tests run on CPU in seconds rather than needing a 2 GB export:

- `test_save_spends_the_proto` pins the in-place mutation the ordering has to work around.
- `test_autocast_precedes_the_save` runs the cast-then-save order from an unrelated working directory and checks the result is valid and parseable from its path.

The old order was confirmed to fail with exactly the reported message before the fix. Full suite: 40 passed, 4 skipped.

Note that these cover the contract, not the call site: the reordering inside `torch2trt()` only runs under TensorRT 11 strong typing, which CI does not have. The real confirmation is a `large-v3-turbo` build at `COMPUTE_TYPE=float16` on a
16GB card — that run is also the first to exercise ModelOpt's own >2 GB spill (a deep copy of a 2.5 GB proto), so give it host RAM headroom.

Refs #551
