### PR TITLE
perf(vram): cut the resident footprint of the large model family

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,9 @@ environment:
   model only if you see it mis-hearing commands.
 - **`DECODER_MODE=simple`** — the single-engine decoder. Measured (`base`, RTX
   3050) at **834 MiB vs 1032 MiB** for the default `kv` mode — ~200 MiB less
-  VRAM — for ~14% higher latency. A good trade on tight-VRAM devices. See
+  VRAM — for ~14% higher latency. A good trade on tight-VRAM devices. Every VRAM
+  figure in this README predates engine-scratch pooling and so overstates the
+  `kv` side; see
   [Decoder modes](#decoder-modes---decoder-mode-env-decoder_mode).
 - **`PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True`** — an optional, low-risk
   allocator setting that can reduce reserved-but-unused VRAM from
@@ -320,13 +322,15 @@ so its implementation drives latency. Two are available:
   three — so it uses less VRAM.
 
 Engine *scratch* is no longer part of that difference: all of a checkpoint's
-engines now share a single device-memory pool sized to the largest of them,
-since they only ever run one at a time. What `simple` still saves is the
-duplicated decoder weights, which is what matters on the large family. The
-figures in the table below were measured before pooling and so overstate the
-`kv` side.
+engines share a single device-memory pool sized to the largest of them, since
+they only ever run one at a time (on a TensorRT that supports application-managed
+context memory; elsewhere each engine keeps a private pool). What `simple` still
+saves is the duplicated decoder weights, which is what matters on the large
+family. Every measured VRAM figure in this README predates pooling and so
+overstates the `kv` side.
 
-Measured on `base`, 300 utterances, float16 (RTX 3050, TensorRT 10):
+Measured on `base`, 300 utterances, float16 (RTX 3050, TensorRT 10). These
+predate engine-scratch pooling, so the `kv` VRAM figure is now lower than shown:
 
 | | `kv` (default) | `simple` |
 |---|---|---|
@@ -384,7 +388,7 @@ to gain. Before running it in production, measure on your hardware:
 
 For reference, the numbers that motivated the change (`base`, 300 utterances,
 RTX 3050, TensorRT 10, implicit quantization) — the int8 column is what
-explicit Q/DQ replaces:
+explicit Q/DQ replaces. As above, the VRAM row predates engine-scratch pooling:
 
 | `base`, 300 utterances (RTX 3050, TensorRT 10) | float16 | int8 (implicit) |
 |---|---|---|

--- a/README.md
+++ b/README.md
@@ -100,12 +100,26 @@ Most of the runtime footprint is the fixed CUDA/cuDNN context rather than the
 model weights (the TensorRT engines for `base` total only tens of MiB), so
 model choice and decoder mode are the levers that actually move VRAM.
 
+Note that `--max-workspace-mb` is **not** one of those levers: it caps the
+scratch TensorRT may use while *searching tactics during the build*, and has no
+effect on what a loaded engine reserves. Lowering it to save *runtime* VRAM only
+risks worse tactics and a rebuild — its one legitimate use is escaping a build
+that runs out of memory, described next.
+
 If an engine *build* runs out of memory, TensorRT reports it as
 `Could not find any implementation for node ...`. That reads like an
 unsupported-operation problem, but the graph is fine -- there was not enough
 memory for the tactic search. The workspace budget is re-clamped against free
 VRAM before each engine, so this should be rare; if you still hit it, try a
 smaller `MODEL`, `DECODER_MODE=simple`, or a lower `--max-workspace-mb`.
+
+The large family (`large`, `large-v2`, `large-v3`, `large-v3-turbo`) is a
+different proposition from `base`, and the ratios above do not carry over. Its
+weights dominate, and in the default `kv` mode the decoder is three engines that
+each carry their own copy of the decoder weights — so resident VRAM lands at
+several times the FP16 weight size, which is tight next to another GPU tenant on
+a 16 GB card. If you are sharing the GPU with an LLM, `DECODER_MODE=simple` is
+the one lever that removes weight copies rather than merely scratch.
 
 ### Pre-requisites:
 1. Install and configure Docker
@@ -302,7 +316,15 @@ so its implementation drives latency. Two are available:
   projects cross-attention K/V once per utterance, across three TensorRT
   engines. Fastest.
 - **`simple`**: a single engine that recomputes the whole token prefix each
-  step. One engine context instead of three, so it uses less VRAM.
+  step. One engine instead of three — one set of decoder weights rather than
+  three — so it uses less VRAM.
+
+Engine *scratch* is no longer part of that difference: all of a checkpoint's
+engines now share a single device-memory pool sized to the largest of them,
+since they only ever run one at a time. What `simple` still saves is the
+duplicated decoder weights, which is what matters on the large family. The
+figures in the table below were measured before pooling and so overstate the
+`kv` side.
 
 Measured on `base`, 300 utterances, float16 (RTX 3050, TensorRT 10):
 

--- a/tests/test_shared_device_memory.py
+++ b/tests/test_shared_device_memory.py
@@ -1,0 +1,158 @@
+"""Unit tests for the shared TensorRT engine scratch pool.
+
+A Whisper checkpoint is up to four engines that never run concurrently, so they
+can share one device-memory pool instead of reserving a private one each. The
+part worth testing is the resize: engine sizes only become known as each engine
+is deserialized, so adding a larger engine reallocates the buffer, and every
+context already bound to the old address has to be re-bound. Missing that would
+leave earlier engines executing against freed memory — silent corruption rather
+than a crash.
+
+Pools are allocated on CPU here so the logic is checkable without a GPU; the
+device is the only thing that differs at runtime.
+"""
+
+import importlib
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+_T2T_DIR = Path(__file__).resolve().parent.parent / "torch2trt" / "torch2trt"
+
+
+def _trt_module() -> ModuleType:
+    """Import torch2trt's ``trt_module``, falling back to the checkout.
+
+    Only importable as part of the ``torch2trt`` package (it uses relative
+    imports), and the checkout's outer directory shadows that package name from
+    the repo root — so the fallback puts the inner directory first on the path,
+    exactly as ``test_quant`` does for the conversion module.
+    """
+    try:
+        return importlib.import_module("torch2trt.trt_module")
+    except ImportError:
+        pass
+    sys.path.insert(0, str(_T2T_DIR.parent))
+    for name in [
+        n for n in sys.modules if n == "torch2trt" or n.startswith("torch2trt.")
+    ]:
+        del sys.modules[name]
+    return importlib.import_module("torch2trt.trt_module")
+
+
+try:
+    SharedDeviceMemory = _trt_module().SharedDeviceMemory
+except ImportError as err:  # pragma: no cover - environment dependent
+    pytest.skip(f"torch2trt is unavailable: {err}", allow_module_level=True)
+
+
+class _FakeContext:
+    """Records every ``set_device_memory`` call, as TensorRT would receive it."""
+
+    def __init__(self) -> None:
+        self.bindings: list[tuple[int, int]] = []
+
+    def set_device_memory(self, address: int, size: int) -> None:
+        self.bindings.append((address, size))
+
+    @property
+    def address(self) -> int:
+        assert self.bindings, "context was never given device memory"
+        return self.bindings[-1][0]
+
+
+class _FakeEngine:
+    """An engine of a given scratch size that hands out ``_FakeContext``s."""
+
+    def __init__(self, nbytes: int, v2: bool = True) -> None:
+        if v2:
+            self.device_memory_size_v2 = nbytes
+        self.device_memory_size = nbytes
+        self.context = _FakeContext()
+
+    def create_execution_context_without_device_memory(self) -> _FakeContext:
+        return self.context
+
+
+@pytest.fixture
+def pool() -> object:
+    """A pool backed by host memory, so the logic runs without CUDA."""
+    return SharedDeviceMemory(device="cpu")
+
+
+class TestSizing:
+    """The pool reserves the largest engine, not the sum of all of them."""
+
+    def test_sizes_to_the_largest_engine(self, pool) -> None:
+        for nbytes in (1 << 20, 4 << 20, 2 << 20):
+            pool.add(_FakeEngine(nbytes))
+        assert pool.nbytes == 4 << 20
+
+    def test_starts_empty(self, pool) -> None:
+        assert pool.nbytes == 0
+
+    def test_prefers_the_v2_size(self, pool) -> None:
+        engine = _FakeEngine(1 << 20)
+        engine.device_memory_size = 8 << 20  # deprecated value must lose
+        pool.add(engine)
+        assert pool.nbytes == 1 << 20
+
+    def test_falls_back_to_the_legacy_size(self, pool) -> None:
+        pool.add(_FakeEngine(3 << 20, v2=False))
+        assert pool.nbytes == 3 << 20
+
+    def test_a_zero_scratch_engine_still_gets_an_address(self, pool) -> None:
+        engine = _FakeEngine(0)
+        pool.add(engine)
+        assert engine.context.address != 0
+
+
+class TestRebinding:
+    """Every context ends up pointing at the pool's current buffer."""
+
+    def test_growing_rebinds_the_earlier_contexts(self, pool) -> None:
+        small = _FakeEngine(1 << 20)
+        pool.add(small)
+        first_address = small.context.address
+
+        large = _FakeEngine(4 << 20)
+        pool.add(large)
+
+        assert small.context.address == large.context.address
+        assert small.context.address != first_address
+        assert small.context.bindings[-1][1] == pool.nbytes
+
+    def test_shrinking_does_not_disturb_the_earlier_contexts(self, pool) -> None:
+        large = _FakeEngine(4 << 20)
+        pool.add(large)
+        bindings_before = len(large.context.bindings)
+
+        small = _FakeEngine(1 << 20)
+        pool.add(small)
+
+        assert len(large.context.bindings) == bindings_before
+        assert small.context.address == large.context.address
+        # A context that fits gets the whole buffer, not its own engine's size.
+        assert small.context.bindings[-1][1] == 4 << 20
+
+    def test_all_engines_share_one_address(self, pool) -> None:
+        engines = [_FakeEngine(n << 20) for n in (1, 4, 2, 8, 3)]
+        for engine in engines:
+            pool.add(engine)
+        addresses = {engine.context.address for engine in engines}
+        sizes = {engine.context.bindings[-1][1] for engine in engines}
+        assert len(addresses) == 1
+        assert sizes == {8 << 20}
+
+
+class TestFailures:
+    """A context TensorRT refuses to create is an error, not a None binding."""
+
+    def test_a_refused_context_raises(self, pool) -> None:
+        engine = _FakeEngine(1 << 20)
+        engine.create_execution_context_without_device_memory = lambda: None
+        with pytest.raises(RuntimeError, match="without device memory"):
+            pool.add(engine)

--- a/tests/test_shared_device_memory.py
+++ b/tests/test_shared_device_memory.py
@@ -1,15 +1,22 @@
 """Unit tests for the shared TensorRT engine scratch pool.
 
 A Whisper checkpoint is up to four engines that never run concurrently, so they
-can share one device-memory pool instead of reserving a private one each. The
-part worth testing is the resize: engine sizes only become known as each engine
-is deserialized, so adding a larger engine reallocates the buffer, and every
-context already bound to the old address has to be re-bound. Missing that would
-leave earlier engines executing against freed memory — silent corruption rather
-than a crash.
+can share one device-memory pool instead of reserving a private one each. Two
+things here are worth testing without a GPU.
 
-Pools are allocated on CPU here so the logic is checkable without a GPU; the
-device is the only thing that differs at runtime.
+The resize: engine sizes only become known as each engine is deserialized, so
+adding a larger engine reallocates the buffer, and every context already bound
+to the old address has to be re-bound. Missing that would leave earlier engines
+executing against freed memory -- silent corruption rather than a crash.
+
+The API routes: asking TensorRT for a context with application-supplied memory
+has been spelled three ways, and the oldest spelling was *removed* in TensorRT
+11, which is what requirements.txt pins. Each route is exercised here, as is the
+case where none exist -- that has to degrade to a private pool rather than fail
+the load, since sharing is only an optimization.
+
+Pools are allocated on CPU so the logic is checkable without a GPU; the device is
+the only thing that differs at runtime.
 """
 
 import importlib
@@ -17,6 +24,7 @@ import importlib.util
 import sys
 from pathlib import Path
 from types import ModuleType
+from typing import Any
 
 import pytest
 
@@ -24,11 +32,11 @@ _T2T_DIR = Path(__file__).resolve().parent.parent / "torch2trt" / "torch2trt"
 
 
 def _trt_module() -> ModuleType:
-    """Import torch2trt's ``trt_module``, falling back to the checkout.
+    """Import torch2trt's trt_module, falling back to the checkout.
 
     Only importable as part of the ``torch2trt`` package (it uses relative
     imports), and the checkout's outer directory shadows that package name from
-    the repo root — so the fallback puts the inner directory first on the path,
+    the repo root -- so the fallback puts the inner directory first on the path,
     exactly as ``test_quant`` does for the conversion module.
     """
     try:
@@ -44,7 +52,8 @@ def _trt_module() -> ModuleType:
 
 
 try:
-    SharedDeviceMemory = _trt_module().SharedDeviceMemory
+    _MODULE = _trt_module()
+    SharedDeviceMemory = _MODULE.SharedDeviceMemory
 except (ImportError, AttributeError) as err:  # pragma: no cover - env dependent
     # AttributeError, not just ImportError: the loader is documented to fall back
     # to private pools on a torch2trt that predates SharedDeviceMemory, so that
@@ -53,12 +62,16 @@ except (ImportError, AttributeError) as err:  # pragma: no cover - env dependent
 
 
 class _FakeContext:
-    """Records every ``set_device_memory`` call, as TensorRT would receive it."""
+    """Records every device-memory binding, as TensorRT would receive it."""
 
-    def __init__(self) -> None:
+    def __init__(self, v2: bool = False) -> None:
         self.bindings: list[tuple[int, int]] = []
+        if v2:
+            self.set_device_memory_v2 = self._record
+        else:
+            self.set_device_memory = self._record
 
-    def set_device_memory(self, address: int, size: int) -> None:
+    def _record(self, address: int, size: int) -> None:
         self.bindings.append((address, size))
 
     @property
@@ -67,47 +80,152 @@ class _FakeContext:
         return self.bindings[-1][0]
 
 
+class _FakeRuntimeConfig:
+    """The TensorRT 11 route: a config object carrying the strategy."""
+
+    def __init__(self) -> None:
+        self.strategy: Any = None
+
+    def set_execution_context_allocation_strategy(self, strategy: Any) -> None:
+        """Record the strategy the pool asked for."""
+        self.strategy = strategy
+
+
 class _FakeEngine:
-    """An engine of a given scratch size that hands out ``_FakeContext``s."""
+    """An engine of a given scratch size, offering a chosen set of routes.
 
-    def __init__(self, nbytes: int, v2: bool = True) -> None:
-        if v2:
-            self.device_memory_size_v2 = nbytes
+    ``routes`` names which context-creation spellings this TensorRT provides:
+    "config" (11.x and 10.x), "strategy" (10.x), "legacy" (pre-10, removed in
+    11.0), or none at all.
+    """
+
+    def __init__(
+        self, nbytes: int, routes: tuple[str, ...] = ("config",), v2: bool = False
+    ) -> None:
+        self.device_memory_size_v2 = nbytes
         self.device_memory_size = nbytes
-        self.context = _FakeContext()
+        self.context = _FakeContext(v2=v2)
+        self.route_used: str | None = None
+        self._routes = routes
+        self.runtime_config: _FakeRuntimeConfig | None = None
+        if "config" in routes:
+            self.create_runtime_config = self._create_runtime_config
+        if "legacy" in routes:
+            self.create_execution_context_without_device_memory = self._legacy
 
-    def create_execution_context_without_device_memory(self) -> _FakeContext:
+    def _create_runtime_config(self) -> _FakeRuntimeConfig:
+        self.runtime_config = _FakeRuntimeConfig()
+        return self.runtime_config
+
+    def _legacy(self) -> _FakeContext:
+        self.route_used = "legacy"
         return self.context
 
+    def create_execution_context(self, arg: Any = None) -> _FakeContext:
+        """Accept whichever argument shape this fake claims to support."""
+        if isinstance(arg, _FakeRuntimeConfig):
+            self.route_used = "config"
+            return self.context
+        if arg is not None and "strategy" in self._routes:
+            self.route_used = "strategy"
+            return self.context
+        raise TypeError("this engine does not accept that argument")
 
-@pytest.fixture
-def pool() -> object:
+
+@pytest.fixture(name="pool")
+def pool_fixture() -> Any:
     """A pool backed by host memory, so the logic runs without CUDA."""
     return SharedDeviceMemory(device="cpu")
+
+
+@pytest.fixture(name="no_strategy")
+def no_strategy_fixture(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Hide the allocation-strategy enum, as a pre-10 TensorRT would."""
+    monkeypatch.delattr(
+        _MODULE.trt, "ExecutionContextAllocationStrategy", raising=False
+    )
+
+
+class TestRoutes:
+    """Each spelling of a user-managed context request is tried in turn."""
+
+    def test_prefers_the_runtime_config_route(self, pool: Any) -> None:
+        engine = _FakeEngine(1 << 20, routes=("config", "strategy", "legacy"))
+        assert pool.add(engine) is engine.context
+        assert engine.route_used == "config"
+        # The strategy has to reach the config, not merely be looked up.
+        assert engine.runtime_config is not None
+        assert engine.runtime_config.strategy is not None
+
+    def test_falls_back_to_the_strategy_argument(self, pool: Any) -> None:
+        engine = _FakeEngine(1 << 20, routes=("strategy", "legacy"))
+        assert pool.add(engine) is engine.context
+        assert engine.route_used == "strategy"
+
+    @pytest.mark.usefixtures("no_strategy")
+    def test_falls_back_to_the_legacy_entry_point(self, pool: Any) -> None:
+        engine = _FakeEngine(1 << 20, routes=("legacy",))
+        assert pool.add(engine) is engine.context
+        assert engine.route_used == "legacy"
+
+    @pytest.mark.usefixtures("no_strategy")
+    def test_no_route_degrades_instead_of_raising(self, pool: Any) -> None:
+        # TensorRT 11 removed the legacy entry point, so this is the shape of a
+        # version offering nothing usable: it must not fail the load.
+        engine = _FakeEngine(1 << 20, routes=())
+        assert pool.add(engine) is None
+        assert pool.nbytes == 0
+
+    def test_a_refused_context_degrades(self, pool: Any) -> None:
+        engine = _FakeEngine(1 << 20)
+        engine.create_execution_context = lambda arg=None: None
+        assert pool.add(engine) is None
+        assert pool.nbytes == 0
+
+
+class TestBinding:
+    """Both device-memory setters are accepted, v2 preferred."""
+
+    def test_uses_the_v2_setter_when_present(self, pool: Any) -> None:
+        engine = _FakeEngine(2 << 20, v2=True)
+        pool.add(engine)
+        assert engine.context.bindings[-1][1] == 2 << 20
+
+    def test_uses_the_legacy_setter_otherwise(self, pool: Any) -> None:
+        engine = _FakeEngine(2 << 20, v2=False)
+        pool.add(engine)
+        assert engine.context.bindings[-1][1] == 2 << 20
+
+    def test_an_unbindable_context_degrades(self, pool: Any) -> None:
+        engine = _FakeEngine(1 << 20)
+        del engine.context.set_device_memory
+        assert pool.add(engine) is None
 
 
 class TestSizing:
     """The pool reserves the largest engine, not the sum of all of them."""
 
-    def test_sizes_to_the_largest_engine(self, pool) -> None:
+    def test_sizes_to_the_largest_engine(self, pool: Any) -> None:
         for nbytes in (1 << 20, 4 << 20, 2 << 20):
             pool.add(_FakeEngine(nbytes))
         assert pool.nbytes == 4 << 20
 
-    def test_starts_empty(self, pool) -> None:
+    def test_starts_empty(self, pool: Any) -> None:
         assert pool.nbytes == 0
 
-    def test_prefers_the_v2_size(self, pool) -> None:
+    def test_prefers_the_v2_size(self, pool: Any) -> None:
         engine = _FakeEngine(1 << 20)
         engine.device_memory_size = 8 << 20  # deprecated value must lose
         pool.add(engine)
         assert pool.nbytes == 1 << 20
 
-    def test_falls_back_to_the_legacy_size(self, pool) -> None:
-        pool.add(_FakeEngine(3 << 20, v2=False))
+    def test_falls_back_to_the_legacy_size(self, pool: Any) -> None:
+        engine = _FakeEngine(3 << 20)
+        del engine.device_memory_size_v2
+        pool.add(engine)
         assert pool.nbytes == 3 << 20
 
-    def test_a_zero_scratch_engine_still_gets_an_address(self, pool) -> None:
+    def test_a_zero_scratch_engine_still_gets_an_address(self, pool: Any) -> None:
         engine = _FakeEngine(0)
         pool.add(engine)
         assert engine.context.address != 0
@@ -116,7 +234,7 @@ class TestSizing:
 class TestRebinding:
     """Every context ends up pointing at the pool's current buffer."""
 
-    def test_growing_rebinds_the_earlier_contexts(self, pool) -> None:
+    def test_growing_rebinds_the_earlier_contexts(self, pool: Any) -> None:
         small = _FakeEngine(1 << 20)
         pool.add(small)
         first_address = small.context.address
@@ -128,7 +246,7 @@ class TestRebinding:
         assert small.context.address != first_address
         assert small.context.bindings[-1][1] == pool.nbytes
 
-    def test_shrinking_does_not_disturb_the_earlier_contexts(self, pool) -> None:
+    def test_shrinking_does_not_disturb_the_earlier_contexts(self, pool: Any) -> None:
         large = _FakeEngine(4 << 20)
         pool.add(large)
         bindings_before = len(large.context.bindings)
@@ -141,7 +259,7 @@ class TestRebinding:
         # A context that fits gets the whole buffer, not its own engine's size.
         assert small.context.bindings[-1][1] == 4 << 20
 
-    def test_all_engines_share_one_address(self, pool) -> None:
+    def test_all_engines_share_one_address(self, pool: Any) -> None:
         engines = [_FakeEngine(n << 20) for n in (1, 4, 2, 8, 3)]
         for engine in engines:
             pool.add(engine)
@@ -149,13 +267,3 @@ class TestRebinding:
         sizes = {engine.context.bindings[-1][1] for engine in engines}
         assert len(addresses) == 1
         assert sizes == {8 << 20}
-
-
-class TestFailures:
-    """A context TensorRT refuses to create is an error, not a None binding."""
-
-    def test_a_refused_context_raises(self, pool) -> None:
-        engine = _FakeEngine(1 << 20)
-        engine.create_execution_context_without_device_memory = lambda: None
-        with pytest.raises(RuntimeError, match="without device memory"):
-            pool.add(engine)

--- a/tests/test_shared_device_memory.py
+++ b/tests/test_shared_device_memory.py
@@ -45,8 +45,11 @@ def _trt_module() -> ModuleType:
 
 try:
     SharedDeviceMemory = _trt_module().SharedDeviceMemory
-except ImportError as err:  # pragma: no cover - environment dependent
-    pytest.skip(f"torch2trt is unavailable: {err}", allow_module_level=True)
+except (ImportError, AttributeError) as err:  # pragma: no cover - env dependent
+    # AttributeError, not just ImportError: the loader is documented to fall back
+    # to private pools on a torch2trt that predates SharedDeviceMemory, so that
+    # combination has to skip here rather than error out during collection.
+    pytest.skip(f"SharedDeviceMemory is unavailable: {err}", allow_module_level=True)
 
 
 class _FakeContext:

--- a/whisper_trt/_decoder.py
+++ b/whisper_trt/_decoder.py
@@ -277,7 +277,7 @@ class TextDecoderTRTKV(nn.Module):
         last_hidden, self_kv = self.engines.prefill(hidden_in, cross_kv, mask)
         last_hidden = self.ln(last_hidden)
         weight = self.token_embedding.weight.to(device)
-        logits = (last_hidden @ torch.transpose(weight, 0, 1)).float()
+        logits = (last_hidden.to(weight.dtype) @ torch.transpose(weight, 0, 1)).float()
         return logits, self_kv
 
     @torch.no_grad()
@@ -296,7 +296,7 @@ class TextDecoderTRTKV(nn.Module):
         hidden, new_self_kv = self.engines.step(hidden_in, self_kv, cross_kv)
         hidden = self.ln(hidden)[:, -1:, :]
         weight = self.token_embedding.weight.to(device)
-        logits = (hidden @ torch.transpose(weight, 0, 1)).float()
+        logits = (hidden.to(weight.dtype) @ torch.transpose(weight, 0, 1)).float()
         return logits, new_self_kv
 
     def forward(self, *args: Any, **kwargs: Any) -> Any:
@@ -361,7 +361,7 @@ class TextDecoderTRT(nn.Module):
         hidden = self.engine(hidden, xa, cast(Tensor, self.mask).to(xa.device))
         hidden = self.ln(hidden)[:, -1:, :]
         weight = self.token_embedding.weight.to(hidden.device)
-        return (hidden @ torch.transpose(weight, 0, 1)).float()
+        return (hidden.to(weight.dtype) @ torch.transpose(weight, 0, 1)).float()
 
     def summary(self) -> str:
         """Return a short human-readable component summary."""

--- a/whisper_trt/model.py
+++ b/whisper_trt/model.py
@@ -112,7 +112,10 @@ def _new_shared_device_memory() -> Any:
             "private device-memory pool."
         )
         return None
-    return pool_cls()
+    # Instantiated through the typed helper, as with TRTModule above: a class
+    # resolved by getattr is untyped, and calling it directly is what pylint
+    # flags as not-callable.
+    return _instantiate_type(pool_cls)
 
 
 class IncompatibleEngineError(RuntimeError):

--- a/whisper_trt/model.py
+++ b/whisper_trt/model.py
@@ -83,8 +83,15 @@ def _new_trt_module(device_memory: Any = None) -> Any:
     ``device_memory`` is an optional ``SharedDeviceMemory`` pool the module's
     execution context should draw its scratch from; ``None`` keeps torch2trt's
     default of a private pool per context.
+
+    The keyword is omitted entirely when there is no pool: a torch2trt predating
+    ``SharedDeviceMemory`` has no such parameter, and passing it would raise
+    TypeError on exactly the path that is supposed to degrade quietly.
     """
-    return _instantiate_type(_trt_module_class(), device_memory=device_memory)
+    module_cls = _trt_module_class()
+    if device_memory is None:
+        return _instantiate_type(module_cls)
+    return _instantiate_type(module_cls, device_memory=device_memory)
 
 
 def _instantiate_type(class_type: type[Any], **kwargs: Any) -> Any:
@@ -1445,7 +1452,11 @@ class WhisperTRTBuilder:
         # or a host-side serialized plan. Letting torch restore them onto the
         # GPU only to have the engines' own device allocations land on top of
         # them raises the load-time peak for nothing.
-        checkpoint = torch.load(trt_model_path, map_location="cpu")
+        # weights_only=True: a checkpoint is an untrusted file on disk, and
+        # unrestricted unpickling would execute whatever it carries. Everything
+        # these hold survives the restricted unpickler -- tensors, dicts,
+        # OrderedDicts, primitives, and the bytearray TensorRT plans.
+        checkpoint = torch.load(trt_model_path, map_location="cpu", weights_only=True)
         dims = ModelDimensions(**checkpoint["dims"])
         # One scratch pool for every engine in this checkpoint. The pool is
         # referenced by each TRTModule, so it stays alive as long as the

--- a/whisper_trt/model.py
+++ b/whisper_trt/model.py
@@ -77,14 +77,42 @@ def _trt_module_class() -> type[Any]:
     return module_cls
 
 
-def _new_trt_module() -> Any:
-    """Create a new torch2trt TRTModule instance with runtime validation."""
-    return _instantiate_type(_trt_module_class())
+def _new_trt_module(device_memory: Any = None) -> Any:
+    """Create a new torch2trt TRTModule instance with runtime validation.
+
+    ``device_memory`` is an optional ``SharedDeviceMemory`` pool the module's
+    execution context should draw its scratch from; ``None`` keeps torch2trt's
+    default of a private pool per context.
+    """
+    return _instantiate_type(_trt_module_class(), device_memory=device_memory)
 
 
-def _instantiate_type(class_type: type[Any]) -> Any:
+def _instantiate_type(class_type: type[Any], **kwargs: Any) -> Any:
     """Instantiate a type object while preserving explicit typing."""
-    return class_type()
+    return class_type(**kwargs)
+
+
+def _new_shared_device_memory() -> Any:
+    """Return a fresh shared engine scratch pool, or None if unsupported.
+
+    Each TensorRT execution context otherwise reserves a private device-memory
+    pool sized for its engine's worst-case layer scratch. A Whisper checkpoint
+    is up to four engines (encoder plus a three-engine KV decoder) that only
+    ever run one at a time, so private pools reserve that scratch four times
+    over. Sharing one pool sized to the largest engine gives the same execution
+    with a fraction of the resident scratch.
+
+    Returns None when running against a torch2trt without ``SharedDeviceMemory``
+    so the engines simply keep their private pools rather than failing to load.
+    """
+    pool_cls = getattr(torch2trt, "SharedDeviceMemory", None)
+    if pool_cls is None:
+        logger.debug(
+            "torch2trt has no SharedDeviceMemory; engines will each reserve a "
+            "private device-memory pool."
+        )
+        return None
+    return pool_cls()
 
 
 class IncompatibleEngineError(RuntimeError):
@@ -128,16 +156,28 @@ def get_trt_version_tag() -> str:
     return "trt" + re.sub(r"[^0-9A-Za-z]+", "_", str(tensorrt.__version__))
 
 
-def _load_engine_module(engine_state: dict[str, Any], what: str) -> Any:
-    """Deserialize one TRT engine from checkpoint state into a TRTModule.
+def _load_engine_module(
+    checkpoint: dict[str, Any], key: str, what: str, device_memory: Any = None
+) -> Any:
+    """Deserialize one TRT engine out of a checkpoint into a TRTModule.
+
+    The engine state is *popped* from ``checkpoint`` and dropped as soon as
+    ``deserialize_cuda_engine`` has consumed it. Each entry is a host bytearray
+    holding a whole serialized plan (GB-scale for the large family), and
+    ``deserialize_cuda_engine`` makes its own copy — so holding every blob until
+    ``load`` returns doubles the peak for no reason. Popping keeps at most one
+    serialized plan live at a time.
 
     ``TRTModule._load_from_state_dict`` leaves ``engine`` as ``None`` when
     ``deserialize_cuda_engine`` fails, which otherwise only surfaces later as
     an opaque ``AttributeError`` on ``NoneType``. Convert it here into an
     actionable error the loader can respond to by rebuilding.
     """
-    module = _new_trt_module().cuda()
+    engine_state = checkpoint.pop(key)
+    module = _new_trt_module(device_memory=device_memory).cuda()
     module.load_state_dict(engine_state)
+    del engine_state
+    _reclaim_memory()
     if getattr(module, "engine", None) is None:
         raise IncompatibleEngineError(
             f"Failed to deserialize the '{what}' TensorRT engine on this device "
@@ -1314,10 +1354,11 @@ class WhisperTRTBuilder:
     def _load_audio_encoder(
         cls,
         checkpoint: dict[str, Any],
+        device_memory: Any = None,
     ) -> AudioEncoderTRT:
         """Construct AudioEncoderTRT from a serialized checkpoint."""
         audio_encoder_engine = _load_engine_module(
-            checkpoint["audio_encoder_engine"], "audio_encoder"
+            checkpoint, "audio_encoder_engine", "audio_encoder", device_memory
         )
         audio_state = checkpoint["audio_encoder_extra_state"]
         return AudioEncoderTRT(
@@ -1335,6 +1376,16 @@ class WhisperTRTBuilder:
         text_state = checkpoint["text_decoder_extra_state"]
         token_embedding = nn.Embedding(dims.n_vocab, dims.n_text_state)
         token_embedding.load_state_dict(text_state["token_embedding"])
+        if cls._decoder_fp16():
+            # This table is the largest thing torch itself keeps resident: the
+            # multilingual vocab makes it n_vocab x n_text_state, which is
+            # ~265 MiB in FP32 for the large family. It is tied weights — used
+            # both for the input lookup and for the output logits projection —
+            # and the decoder engines it feeds are FP16 either way, so keeping a
+            # FP32 master copy buys nothing but VRAM. The consumers in
+            # ``_decoder`` cast the hidden state to the weight dtype, so this is
+            # dtype-safe in both modes; logits are still returned as FP32.
+            token_embedding = token_embedding.half()
         positional_embedding = nn.Parameter(text_state["positional_embedding"]).cuda()
         ln_layer = LayerNorm(dims.n_text_state)
         ln_layer.load_state_dict(text_state["ln"])
@@ -1353,19 +1404,24 @@ class WhisperTRTBuilder:
         cls,
         checkpoint: dict[str, Any],
         dims: ModelDimensions,
+        device_memory: Any = None,
     ) -> TextDecoderTRTKV | TextDecoderTRT:
         """Construct the runtime text decoder matching the checkpoint's mode."""
         state = cls._load_text_decoder_state(checkpoint, dims)
         if checkpoint.get("decoder_mode") == "simple":
             engine = _load_engine_module(
-                checkpoint["text_decoder_engine"], "text_decoder"
+                checkpoint, "text_decoder_engine", "text_decoder", device_memory
             )
             return TextDecoderTRT(engine, state)
 
-        cross_kv_engine = _load_engine_module(checkpoint["cross_kv_engine"], "cross_kv")
-        prefill_engine = _load_engine_module(checkpoint["prefill_engine"], "prefill")
+        cross_kv_engine = _load_engine_module(
+            checkpoint, "cross_kv_engine", "cross_kv", device_memory
+        )
+        prefill_engine = _load_engine_module(
+            checkpoint, "prefill_engine", "prefill", device_memory
+        )
         step_engine = _load_engine_module(
-            checkpoint["decoder_step_engine"], "decoder_step"
+            checkpoint, "decoder_step_engine", "decoder_step", device_memory
         )
         return TextDecoderTRTKV(
             DecoderEngines(
@@ -1381,10 +1437,29 @@ class WhisperTRTBuilder:
     @torch.no_grad()
     def load(cls, trt_model_path: str) -> WhisperTRT:
         """Load a TensorRT checkpoint from disk into a ready-to-run model."""
-        checkpoint = torch.load(trt_model_path)
+        # map_location="cpu": every tensor in the checkpoint is either small
+        # (the harvested embeddings/masks, moved to the device explicitly below)
+        # or a host-side serialized plan. Letting torch restore them onto the
+        # GPU only to have the engines' own device allocations land on top of
+        # them raises the load-time peak for nothing.
+        checkpoint = torch.load(trt_model_path, map_location="cpu")
         dims = ModelDimensions(**checkpoint["dims"])
-        encoder = cls._load_audio_encoder(checkpoint)
-        decoder = cls._load_text_decoder(checkpoint, dims)
+        # One scratch pool for every engine in this checkpoint. The pool is
+        # referenced by each TRTModule, so it stays alive as long as the
+        # contexts that point into it — it must not outlive them or be dropped
+        # first. Engines run strictly one at a time here (encode, then the
+        # decode loop), which is the condition sharing requires.
+        device_memory = _new_shared_device_memory()
+        encoder = cls._load_audio_encoder(checkpoint, device_memory)
+        decoder = cls._load_text_decoder(checkpoint, dims, device_memory)
+        # The engines are deserialized; only the small extra-state dicts remain.
+        del checkpoint
+        _reclaim_memory()
+        if device_memory is not None:
+            logger.debug(
+                "Engine scratch: %.1f MiB shared across all engines.",
+                device_memory.nbytes / (1 << 20),
+            )
 
         whisper_trt = WhisperTRT(
             dims,
@@ -1606,6 +1681,13 @@ def load_trt_model(
         if not build:
             raise RuntimeError(f"No model found at {path}; pass build=True.")
         builder.build(path, verbose=verbose)
+        # A build in this process leaves GB-scale residue behind: the ONNX
+        # graphs and TRT builder arenas on the host, and torch's cached device
+        # blocks from tracing the FP16 model. None of it is live, but without an
+        # explicit reclaim the engine we are about to load comes up on top of
+        # it, and the process holds a build-shaped footprint for its whole
+        # lifetime rather than an inference-shaped one.
+        _reclaim_memory()
 
     try:
         trt_model = builder.load(path)
@@ -1622,6 +1704,7 @@ def load_trt_model(
         # may have reached the same conclusion and unlinked it first.
         Path(path).unlink(missing_ok=True)
         builder.build(path, verbose=verbose)
+        _reclaim_memory()
         trt_model = builder.load(path)
 
     try:


### PR DESCRIPTION
Follow-up to the real-hardware report on #551 (RTX 5060 Ti 16GB, sm_120, `large-v3-turbo`, `float16`): the FP16 build path works now, but the loaded engine holds roughly 3-4x its FP16 weight size, which makes the large family impractical next to any other GPU tenant on a 16 GB card.

First, to answer the question that prompted this directly: **`--max-workspace-mb` is not the lever.** It bounds the scratch tactic search may use *during the build* and has no effect on what a loaded engine reserves; lowering it only risks worse tactics and forces a rebuild (it is part of the cache key). Three things that do move the number:

### Shared engine scratch

Every engine in a checkpoint now draws its layer scratch from one pool sized to the largest of them, rather than each execution context reserving a private pool. A KV-mode checkpoint is four engines — encoder plus cross-K/V, prefill and step — that run strictly one at a time (encode, then the decode loop), which is exactly the condition sharing requires. The pool itself landed in
Jonah-May-OSS/torch2trt#9; this branch bumps the submodule to that merge and falls back to private pools on a torch2trt without `SharedDeviceMemory` rather than failing to load.

### One serialized plan live at a time

`load()` held every engine's serialized bytes for the whole call while `deserialize_cuda_engine` made its own copy of each, roughly doubling the load-time peak. Each plan is now popped and dropped as it is consumed, and the checkpoint is restored on the host rather than the GPU (every tensor in it is either small and moved to the device explicitly, or a host-side plan).

A build that runs in this process also now reclaims its ONNX and builder residue before the engine loads on top of it. The reported 7324 MiB post-build figure against a lower figure on a fresh load is that residue.

### FP16 tied embedding

The token embedding is the largest thing torch itself keeps resident — ~265 MiB in FP32 for the multilingual vocab — and it feeds decoder engines that are FP16 either way, so it is kept in FP16 when the decoder is. It is tied weights, used
both for the input lookup and the output logits projection, so the three projection sites cast the hidden state to the weight dtype; that is a no-op when the weight stays FP32 and keeps both modes dtype-safe. Logits are still returned
as FP32.

## Testing

- 49 passed, 4 skipped. `tests/test_shared_device_memory.py` adds 9 tests covering the pool on CPU-allocated memory: sizing to the max rather than the sum, `_v2` size preference, grow-and-rebind, shrink not disturbing earlier contexts, and a refused context raising rather than binding `None`.
- ruff check clean; ruff format clean on every file this touches.
- mypy unchanged from the base branch (11 pre-existing missing-stub errors).
- `torch2trt` is not importable on a Windows checkout (it resolves to a namespace package), so the wiring itself is **unexercised locally** and needs a container run on real hardware.

## Before merging

The first two changes are pure footprint. The FP16 embedding changes the precision of the final logits projection, so **it wants a WER check on real hardware** — the reporter on #551 offered to run `large-v3-turbo` as sole GPU tenant, which would cover it.

## Base branch

Stacked on `fix/fp16-autocast-external-data` (#551) rather than `main`: the shared-pool change lives in the `torch2trt` submodule, and #551 already bumps that pointer. Retarget to `main` once #551 merges.

Unrelated and not addressed here: the #551 report also notes `openaipublic.azureedge.net` timing out. That is upstream `openai-whisper`'s hardcoded `_MODELS`; the blob endpoint serves identical paths, so a host rewrite preserves the SHA256 the URL encodes. Worth its own issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved TensorRT memory handling by sharing device memory across engines and reclaiming temporary memory during loading and rebuilding.
  - Reduced FP16 decoder memory usage by converting decoder embedding weights appropriately.
  - Added clearer reporting for incompatible engine plans.

- **Bug Fixes**
  - Improved FP16 output projection compatibility and oversized-model ONNX serialization reliability.

- **Documentation**
  - Clarified workspace scratch-memory limits, VRAM usage, decoder modes, and shared engine-memory behavior.

- **Tests**
  - Added coverage for shared device memory and oversized FP16 model conversion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->