### PR TITLE
docs: tell Jetson users which image matches their JetPack

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Thor-only.)
 The `-igpu` image is JetPack 6 only. Running it on JetPack 7 loops on startup
 with:
 
-```
+```text
 ImportError: libnvdla_compiler.so: cannot open shared object file: No such file or directory
 ```
 

--- a/README.md
+++ b/README.md
@@ -122,6 +122,31 @@ model choice and decoder mode are the levers that actually move VRAM.
    Requires Docker 23 or newer (JetPack 5 ships Docker 20.10, which cannot pull these
    images -- build locally from the Dockerfile instead).
 
+### Which image for a Jetson?
+
+| JetPack | Image |
+|---|---|
+| 6.x (L4T r36) | `captnspdr/wyoming-whisper-trt:latest-igpu` |
+| 7.2+ (L4T r39.2) | `captnspdr/wyoming-whisper-trt:latest` (the standard ARM64 image) |
+
+JetPack 7.2 aligns Orin with the SBSA baseline, so a Jetson on r39.2 runs
+mainstream ARM64 containers directly and the `-igpu` tag is no longer needed --
+follow the discrete-GPU instructions below and use the plain `latest` tag.
+(JetPack 7.2 is the first 7.x release covering the Orin family; 7.0 and 7.1 are
+Thor-only.)
+
+The `-igpu` image is JetPack 6 only. Running it on JetPack 7 loops on startup
+with:
+
+```
+ImportError: libnvdla_compiler.so: cannot open shared object file: No such file or directory
+```
+
+That library was dropped in JetPack 7 and cannot be installed; the fix is the
+standard image, not a workaround. The JetPack 7 path is untested here (I have no
+Jetson) -- reports welcome on
+[#1038](https://github.com/Jonah-May-OSS/wyoming-whisper-trt/issues/1038).
+
 ### Docker Compose (recommended)
 For discrete GPUs (AMD64 or ARM64):
 ```
@@ -151,7 +176,8 @@ services:
               capabilities: [gpu]
 ```
 
-For ARM64 with an iGPU like Jetson devices:
+For ARM64 with an iGPU like Jetson devices (JetPack 6 only -- see
+[Which image for a Jetson?](#which-image-for-a-jetson)):
 ```
 services:
   wyoming-whisper-trt:
@@ -197,7 +223,8 @@ docker run \
   captnspdr/wyoming-whisper-trt:latest
 ```
 
-For ARM64 with iGPU:
+For ARM64 with iGPU (JetPack 6 only -- see
+[Which image for a Jetson?](#which-image-for-a-jetson)):
 
 ```bash
 docker run \

--- a/README.md
+++ b/README.md
@@ -143,9 +143,13 @@ ImportError: libnvdla_compiler.so: cannot open shared object file: No such file 
 ```
 
 That library was dropped in JetPack 7 and cannot be installed; the fix is the
-standard image, not a workaround. The JetPack 7 path is untested here (I have no
-Jetson) -- reports welcome on
-[#1038](https://github.com/Jonah-May-OSS/wyoming-whisper-trt/issues/1038).
+standard image, not a workaround.
+
+The JetPack 7 path is confirmed working on an Orin Nano 8 GB (JetPack 7.2,
+L4T R39.2.0): CUDA is available, the engine builds, and transcription is
+TensorRT-accelerated. Torch prints one harmless warning at startup about the
+GPU's compute capability (`sm_87`) not being in its published build list --
+CUDA runs `sm_80` code on any 8.x GPU, so this costs nothing.
 
 ### Docker Compose (recommended)
 For discrete GPUs (AMD64 or ARM64):


### PR DESCRIPTION
The -igpu image is built on nvcr.io/nvidia/pytorch:26.02-py3-igpu, whose bundled TensorRT (10.11.0.33+jp6) links libnvdla_compiler.so. That library ships with the Jetson host driver and is injected by the NVIDIA container runtime; JetPack 7 dropped it and no apt package provides it, so the container loops on ImportError at startup (#1038).

There is nothing to fix in the -igpu image: JetPack 7.2 aligns Orin with the SBSA baseline, so those devices run mainstream ARM64 containers directly and the -igpu tag is no longer needed. NVIDIA stopped publishing standalone -igpu tags after 26.02 for the same reason.

So document the routing instead of chasing a JetPack 7 -igpu build: JetPack 6 keeps latest-igpu, JetPack 7.2+ uses the standard latest ARM64 image. Flags the JetPack 7 path as untested, since there is no Jetson here to verify it on.

Refs #1038

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for selecting the appropriate container image based on JetPack versions.
  * Clarified that the `-igpu` image is supported only with JetPack 6.
  * Documented that JetPack 7.2+ should use the standard ARM64 image.
  * Confirmed standard image compatibility and TensorRT acceleration on Orin Nano 8 GB.
  * Updated iGPU usage instructions to identify JetPack 6-specific steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->