### PR TITLE
fix: re-clamp the TRT workspace per engine and name build OOMs as OOM

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,13 @@ Most of the runtime footprint is the fixed CUDA/cuDNN context rather than the
 model weights (the TensorRT engines for `base` total only tens of MiB), so
 model choice and decoder mode are the levers that actually move VRAM.
 
+If an engine *build* runs out of memory, TensorRT reports it as
+`Could not find any implementation for node ...`. That reads like an
+unsupported-operation problem, but the graph is fine -- there was not enough
+memory for the tactic search. The workspace budget is re-clamped against free
+VRAM before each engine, so this should be rare; if you still hit it, try a
+smaller `MODEL`, `DECODER_MODE=simple`, or a lower `--max-workspace-mb`.
+
 ### Pre-requisites:
 1. Install and configure Docker
 2. Install and configure the [Nvidia Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html)

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -88,3 +88,97 @@ def test_falls_back_to_target_when_cuda_info_unavailable() -> None:
     ):
         assert auto_workspace_mb("large-v3") == _LARGE_WORKSPACE_MB
         assert auto_workspace_mb("base") == _DEFAULT_WORKSPACE_MB
+
+
+class TestEffectiveWorkspace:
+    """The per-engine re-clamp applied just before each engine build.
+
+    ``auto_workspace_mb`` runs once, before anything is resident. A "kv" build
+    then makes four engines in sequence, each leaving weights in VRAM, so the
+    free memory that sized the original budget is gone by the last build.
+    ``_effective_workspace`` re-reads free VRAM before each one.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _restore_builder_state(self):
+        # These set class attributes, so put them back or the next test in the
+        # session inherits whatever the last one left behind.
+        from whisper_trt.model import WhisperTRTBuilder
+
+        size = WhisperTRTBuilder.max_workspace_size
+        explicit = WhisperTRTBuilder.max_workspace_explicit
+        yield
+        WhisperTRTBuilder.max_workspace_size = size
+        WhisperTRTBuilder.max_workspace_explicit = explicit
+
+    def _builder(self, size_mb: int, explicit: bool):
+        from whisper_trt.model import WhisperTRTBuilder
+
+        WhisperTRTBuilder.max_workspace_size = size_mb * _MIB
+        WhisperTRTBuilder.max_workspace_explicit = explicit
+        return WhisperTRTBuilder
+
+    def test_auto_budget_shrinks_as_vram_fills(self) -> None:
+        builder = self._builder(4096, explicit=False)
+        # Ample VRAM: the up-front budget survives untouched.
+        with _free_vram(16 * 1024):
+            assert builder._effective_workspace() == 4096 * _MIB
+        # Three engines later there is far less free, so the stale ceiling is
+        # cut down rather than letting tactic search reserve what isn't there.
+        with _free_vram(4 * 1024):
+            clamped = builder._effective_workspace()
+        assert (
+            clamped
+            == int(_VRAM_FRACTION * (4 * 1024 - _BUILD_MEMORY_RESERVE_MB)) * _MIB
+        )
+        assert clamped < 4096 * _MIB
+
+    def test_explicit_budget_is_never_shrunk(self) -> None:
+        # --max-workspace-mb is a number the user asked for; silently reducing
+        # it would make the flag a suggestion.
+        builder = self._builder(4096, explicit=True)
+        with _free_vram(3 * 1024):
+            assert builder._effective_workspace() == 4096 * _MIB
+
+    def test_never_drops_below_the_floor(self) -> None:
+        builder = self._builder(4096, explicit=False)
+        with _free_vram(_BUILD_MEMORY_RESERVE_MB):
+            assert builder._effective_workspace() == _MIN_WORKSPACE_MB * _MIB
+
+    def test_falls_back_to_the_budget_without_cuda_info(self) -> None:
+        builder = self._builder(1024, explicit=False)
+        with patch(
+            "whisper_trt.model.torch.cuda.mem_get_info",
+            side_effect=RuntimeError("no cuda"),
+        ):
+            assert builder._effective_workspace() == 1024 * _MIB
+
+
+class TestBuildOomDetection:
+    """Recognising a TensorRT build OOM from its misleading message."""
+
+    @pytest.mark.parametrize(
+        "message",
+        [
+            "Could not find any implementation for node {ForeignNode[...]}",
+            "[graph] no implementation obeys reformatting-free rules",
+            "Cuda Runtime (out of memory)",
+            "std::bad_alloc: OutOfMemory",
+        ],
+    )
+    def test_oom_shapes_are_recognised(self, message: str) -> None:
+        from whisper_trt.model import _looks_like_build_oom
+
+        assert _looks_like_build_oom(message)
+
+    @pytest.mark.parametrize(
+        "message",
+        [
+            "Unsupported ONNX opset version: 21",
+            "Network has dynamic or shape inputs, but no optimization profile",
+        ],
+    )
+    def test_unrelated_failures_are_left_alone(self, message: str) -> None:
+        from whisper_trt.model import _looks_like_build_oom
+
+        assert not _looks_like_build_oom(message)

--- a/whisper_trt/model.py
+++ b/whisper_trt/model.py
@@ -157,6 +157,24 @@ def _invoke_converter(
     return converter(module, inputs, **kwargs)
 
 
+# TensorRT reports a build that ran out of memory by naming the node whose
+# tactics it could not fit, which reads as an unsupported-op or bad-export
+# problem and sends people looking in the wrong place entirely. These are the
+# markers seen on memory-constrained devices; matched case-insensitively.
+_OOM_BUILD_MARKERS = (
+    "could not find any implementation for node",
+    "no implementation obeys reformatting-free rules",
+    "out of memory",
+    "outofmemory",
+)
+
+
+def _looks_like_build_oom(message: str) -> bool:
+    """Return True when a TensorRT build failure reads as memory exhaustion."""
+    lowered = message.lower()
+    return any(marker in lowered for marker in _OOM_BUILD_MARKERS)
+
+
 def _torch2trt_convert(
     module: nn.Module, inputs: list[torch.Tensor], **kwargs: Any
 ) -> Any:
@@ -164,7 +182,25 @@ def _torch2trt_convert(
     converter = getattr(torch2trt, "torch2trt", None)
     if converter is None or not callable(converter):
         raise RuntimeError("torch2trt.torch2trt is unavailable")
-    return _invoke_converter(converter, module, inputs, **kwargs)
+    workspace_mb = int(kwargs.get("max_workspace_size", 0)) >> 20
+    logger.debug(
+        "Building TensorRT engine with a %d MiB workspace; %s.",
+        workspace_mb,
+        _describe_free_vram(),
+    )
+    try:
+        return _invoke_converter(converter, module, inputs, **kwargs)
+    except Exception as err:  # re-raised below; TRT's type varies by version
+        if not _looks_like_build_oom(str(err)):
+            raise
+        raise RuntimeError(
+            "TensorRT ran out of memory building this engine "
+            f"(workspace {workspace_mb} MiB; {_describe_free_vram()}). "
+            "TensorRT reports this as a missing implementation for a node, but "
+            "the graph is supported -- there was not enough memory for the "
+            "tactic search. Try a smaller model, --decoder-mode simple, or a "
+            "lower --max-workspace-mb."
+        ) from err
 
 
 def _trt_log_level(verbose: bool) -> int:
@@ -173,6 +209,16 @@ def _trt_log_level(verbose: bool) -> int:
     if logger_cls is None:
         raise RuntimeError("tensorrt.Logger is unavailable")
     return logger_cls.VERBOSE if verbose else logger_cls.ERROR
+
+
+def _describe_free_vram() -> str:
+    """Return a short human-readable free/total VRAM string for log messages."""
+    try:
+        free_bytes, total_bytes = torch.cuda.mem_get_info()
+    except (RuntimeError, AssertionError):
+        return "free VRAM unknown"
+    mib = 1 << 20
+    return f"{free_bytes // mib} MiB free of {total_bytes // mib} MiB"
 
 
 def _resolve_malloc_trim() -> Callable[[int], int] | None:
@@ -835,9 +881,47 @@ class WhisperTRTBuilder:
     # worse tactics and raised WER. Lower via --max-workspace-mb only as an
     # OOM escape hatch when building a very large model.
     max_workspace_size: int = 1 << 30
+    # True when max_workspace_size came from --max-workspace-mb. An explicit
+    # budget is honoured as given; only the auto-selected one is re-clamped
+    # per engine (see _effective_workspace).
+    max_workspace_explicit: bool = False
     verbose: bool = False
     _tokenizer: Tokenizer | None = None
     _dims: ModelDimensions | None = None
+
+    @classmethod
+    def _effective_workspace(cls) -> int:
+        """Return the workspace budget for the engine about to be built.
+
+        ``auto_workspace_mb`` runs once, before the build, when nothing is
+        resident yet -- no Whisper weights, no finished engines. A "kv" build
+        then makes four engines in sequence, each one leaving its weights in
+        VRAM, so by the last build the free memory that sized the budget is
+        long gone and the stale ceiling can let tactic search reserve more than
+        is left. Re-clamping against *current* free VRAM before each build is
+        what keeps the later engines in a sequence from OOMing on a small GPU.
+
+        An explicit --max-workspace-mb is returned untouched: the user asked
+        for that number, and silently shrinking it would make the flag a
+        suggestion.
+        """
+        if cls.max_workspace_explicit:
+            return cls.max_workspace_size
+        try:
+            free_bytes, _total = torch.cuda.mem_get_info()
+        except (RuntimeError, AssertionError):
+            return cls.max_workspace_size
+        spare_mb = free_bytes / (1 << 20) - _BUILD_MEMORY_RESERVE_MB
+        cap_mb = max(_MIN_WORKSPACE_MB, int(_WORKSPACE_VRAM_FRACTION * spare_mb))
+        clamped = min(cls.max_workspace_size, cap_mb << 20)
+        if clamped < cls.max_workspace_size:
+            logger.debug(
+                "Clamping workspace from %d MiB to %d MiB for this engine (%s).",
+                cls.max_workspace_size >> 20,
+                clamped >> 20,
+                _describe_free_vram(),
+            )
+        return clamped
 
     @classmethod
     def get_compute_type(cls) -> str:
@@ -902,7 +986,7 @@ class WhisperTRTBuilder:
                 int8_mode=False,
                 input_names=["xa"],
                 output_names=["cross_kv"],
-                max_workspace_size=cls.max_workspace_size,
+                max_workspace_size=cls._effective_workspace(),
                 fp16_mode=cls._decoder_fp16(),
                 log_level=_trt_log_level(cls.verbose),
             )
@@ -953,7 +1037,7 @@ class WhisperTRTBuilder:
                 ],
                 input_names=["x", "cross_kv", "mask"],
                 output_names=["last_hidden", "self_kv"],
-                max_workspace_size=cls.max_workspace_size,
+                max_workspace_size=cls._effective_workspace(),
                 fp16_mode=cls._decoder_fp16(),
                 log_level=_trt_log_level(cls.verbose),
             )
@@ -1006,7 +1090,7 @@ class WhisperTRTBuilder:
                 ],
                 input_names=["x", "self_kv", "cross_kv"],
                 output_names=["hidden", "new_self_kv"],
-                max_workspace_size=cls.max_workspace_size,
+                max_workspace_size=cls._effective_workspace(),
                 fp16_mode=cls._decoder_fp16(),
                 log_level=_trt_log_level(cls.verbose),
             )
@@ -1056,7 +1140,7 @@ class WhisperTRTBuilder:
                 ],
                 input_names=["x", "xa", "mask"],
                 output_names=["output"],
-                max_workspace_size=cls.max_workspace_size,
+                max_workspace_size=cls._effective_workspace(),
                 fp16_mode=cls._decoder_fp16(),
                 log_level=_trt_log_level(cls.verbose),
             )
@@ -1113,7 +1197,7 @@ class WhisperTRTBuilder:
                 ],
                 input_names=["x", "positional_embedding"],
                 output_names=["output"],
-                max_workspace_size=cls.max_workspace_size,
+                max_workspace_size=cls._effective_workspace(),
                 # Everything the Q/DQ pairs don't cover (attention matmuls,
                 # layer norms, softmax) is cast to FP16 in the same quantizer
                 # pass, so an int8 encoder is INT8-where-quantized, FP16 else.

--- a/wyoming_whisper_trt/__main__.py
+++ b/wyoming_whisper_trt/__main__.py
@@ -425,6 +425,7 @@ async def main() -> None:
     # Resolve the build-time workspace budget. When unset, pick one from the
     # model size and free VRAM (more generous for large models); an explicit
     # --max-workspace-mb always wins. Does not control runtime VRAM.
+    WhisperTRTBuilder.max_workspace_explicit = args.max_workspace_mb is not None
     if args.max_workspace_mb is None:
         args.max_workspace_mb = auto_workspace_mb(model_name)
         logger.debug("Auto-selected TensorRT workspace: %d MiB.", args.max_workspace_mb)


### PR DESCRIPTION
auto_workspace_mb runs once, in __main__, before anything is resident -- no Whisper weights, no finished engines. A "kv" build then makes four engines in sequence, each leaving its weights in VRAM, so by the last build the free memory that sized the budget is long gone while the ceiling still reflects an empty GPU. Tactic search could then reserve more than was left and OOM the build on a small device.

Re-clamp against current free VRAM before each engine. An explicit --max-workspace-mb is passed through untouched: the user asked for that number, and silently shrinking it would make the flag a suggestion.

TensorRT reports a build OOM as "Could not find any implementation for node ...", which reads as an unsupported op or a bad export and sends people looking in the wrong place -- as it did in #1039, where the reporter had to work out for themselves that it meant memory. Recognise the OOM-shaped failures and re-raise naming the cause, the workspace in use, free VRAM, and the levers that help. Log the workspace and free VRAM before each build so a failure shows what it was working with.

Refs #1039