### PR TITLE
fix: silence torch's sm_87 "unsupported GPU" warning on Jetson Orin

### DIFF
--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -208,6 +208,24 @@ class TestUnsupportedArchWarningFilter:
             "supports hardware CC range(90, 100)"
         )
 
+    def test_older_torch_wording_is_also_silenced(self) -> None:
+        # torch reworded this message; both phrasings mean the same thing.
+        assert self._filtered(
+            "Found GPU0 Orin which is of cuda capability 8.7.\n"
+            "Minimum and Maximum cuda capability supported by this version "
+            "of PyTorch is (9.0) (12.0)"
+        )
+
+    def test_same_warning_about_another_gpu_is_not_silenced(self) -> None:
+        # Same message, same prefix, different capability: a card that really
+        # is unsupported must still warn, so the pattern pins 8.7 rather than
+        # matching any "Found GPU ... compute capability" line.
+        assert not self._filtered(
+            "Found GPU0 NVIDIA GeForce GTX 750 Ti which is of compute "
+            "capability (CC) 5.0.\nThe following list shows the CCs this "
+            "version of PyTorch was built for"
+        )
+
     def test_other_warnings_still_surface(self) -> None:
         # A genuinely unsupported GPU, and unrelated warnings, must not be
         # swallowed by a filter aimed at one cosmetic message.

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -4,6 +4,7 @@ These exercise ``auto_workspace_mb`` with ``torch.cuda.mem_get_info`` mocked,
 so they run on CPU-only CI runners (no real GPU required).
 """
 
+import warnings
 from unittest.mock import patch
 
 import pytest
@@ -182,3 +183,36 @@ class TestBuildOomDetection:
         from whisper_trt.model import _looks_like_build_oom
 
         assert not _looks_like_build_oom(message)
+
+
+class TestUnsupportedArchWarningFilter:
+    """The Orin sm_87 startup warning is silenced, but only that one."""
+
+    def _filtered(self, message: str) -> bool:
+        """Return True when the installed filter would suppress ``message``."""
+        from wyoming_whisper_trt.__main__ import _silence_unsupported_arch_warning
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.resetwarnings()
+            _silence_unsupported_arch_warning()
+            warnings.warn(message, UserWarning, stacklevel=1)
+            return not caught
+
+    def test_orin_capability_warning_is_silenced(self) -> None:
+        # The real message is multi-line; torch emits the "Found GPU" line
+        # first and filters match from the start of the message.
+        assert self._filtered(
+            "Found GPU0 Orin which is of compute capability (CC) 8.7.\n"
+            "The following list shows the CCs this version of PyTorch was "
+            "built for and the hardware CCs it supports:\n- 9.0 which "
+            "supports hardware CC range(90, 100)"
+        )
+
+    def test_other_warnings_still_surface(self) -> None:
+        # A genuinely unsupported GPU, and unrelated warnings, must not be
+        # swallowed by a filter aimed at one cosmetic message.
+        assert not self._filtered(
+            "NVIDIA GeForce GTX 780 with CUDA capability sm_35 is not "
+            "compatible with the current PyTorch installation."
+        )
+        assert not self._filtered("some unrelated deprecation")

--- a/wyoming_whisper_trt/__main__.py
+++ b/wyoming_whisper_trt/__main__.py
@@ -414,12 +414,15 @@ def _silence_unsupported_arch_warning() -> None:
     natively on sm_87. The warning is a list lookup, not a measurement, and it
     reads as a fatal misconfiguration to anyone reading container logs.
 
-    Deliberately narrow: it matches only this message, so a genuinely
-    unsupported GPU still warns. Must run before anything touches CUDA.
+    Deliberately narrow: the pattern pins capability 8.7, so the same warning
+    about a genuinely unsupported GPU (a CC 5.0 card, say) still reaches the
+    log. Both phrasings are matched because torch reworded the message; the
+    filter is anchored at the start, which is where "Found GPU" sits. Must run
+    before anything touches CUDA.
     """
     warnings.filterwarnings(
         "ignore",
-        message=r".*Found GPU.*compute capability.*",
+        message=r"Found GPU.*(?:compute capability \(CC\)|cuda capability) 8\.7",
         category=UserWarning,
     )
 

--- a/wyoming_whisper_trt/__main__.py
+++ b/wyoming_whisper_trt/__main__.py
@@ -14,6 +14,7 @@ import math
 import os
 import sys
 import time
+import warnings
 from collections.abc import Callable
 from functools import partial
 from pathlib import Path
@@ -403,8 +404,31 @@ def _validate_args(args: argparse.Namespace) -> None:
         sys.exit(1)
 
 
+def _silence_unsupported_arch_warning() -> None:
+    """Drop torch's "this GPU is unsupported" warning on Jetson Orin.
+
+    Torch compares the device's compute capability against the arch list its
+    wheel was published for. Orin is sm_87, which the ARM64 CUDA wheels do not
+    name, so torch warns at CUDA init -- but CUDA runs a cubin on any GPU
+    sharing its major version, so the sm_80 code in those wheels executes
+    natively on sm_87. The warning is a list lookup, not a measurement, and it
+    reads as a fatal misconfiguration to anyone reading container logs.
+
+    Deliberately narrow: it matches only this message, so a genuinely
+    unsupported GPU still warns. Must run before anything touches CUDA.
+    """
+    warnings.filterwarnings(
+        "ignore",
+        message=r".*Found GPU.*compute capability.*",
+        category=UserWarning,
+    )
+
+
 async def main() -> None:
     """Main entry point."""
+    # Before _parse_args: auto_workspace_mb reads mem_get_info below, and that
+    # initialises CUDA, which is what emits the warning.
+    _silence_unsupported_arch_warning()
     args = _parse_args()
     _validate_args(args)
 


### PR DESCRIPTION
Torch compares the device's compute capability against the arch list its wheel was published for. Orin is sm_87, which the ARM64 CUDA wheels do not name, so torch warns at CUDA init. CUDA runs a cubin on any GPU sharing its major version, so the sm_80 code in those wheels executes natively on sm_87 -- the check is a list lookup, not a measurement.

Confirmed harmless on an Orin Nano 8 GB (JetPack 7.2): CUDA available and transcription TensorRT-accelerated at RTF 0.071, with this warning on every start. It reads as a fatal misconfiguration in container logs.

The filter matches only this message, so a genuinely unsupported GPU still warns, and it is installed at the top of main() because auto_workspace_mb's mem_get_info call initialises CUDA.

Refs #1038

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced unnecessary startup warnings on supported Orin hardware.
  * Preserved visibility of unrelated and genuinely unsupported-GPU warnings.

* **Tests**
  * Added coverage to verify that only the targeted warning is suppressed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->