### PR TITLE
fix(decode): wait for the mel's stream before the encoder reads it

### DIFF
--- a/tests/test_decode_stream_sync.py
+++ b/tests/test_decode_stream_sync.py
@@ -85,14 +85,20 @@ def recorded_fixture(monkeypatch: pytest.MonkeyPatch) -> _Recorder:
     """Run ``_decode_mel`` against fakes and return the ordered call log."""
     rec = _Recorder()
     producer = _FakeStream("producer", rec)
+    current_stream = producer
 
     @contextmanager
     def fake_stream_ctx(stream: _FakeStream):
+        nonlocal current_stream
         rec.events.append(f"enter({stream.name})")
-        yield
-        rec.events.append(f"exit({stream.name})")
+        current_stream = stream
+        try:
+            yield
+        finally:
+            current_stream = producer
+            rec.events.append(f"exit({stream.name})")
 
-    monkeypatch.setattr(model_module.torch.cuda, "current_stream", lambda: producer)
+    monkeypatch.setattr(model_module.torch.cuda, "current_stream", lambda: current_stream)
     monkeypatch.setattr(model_module.torch.cuda, "stream", fake_stream_ctx)
 
     fake = _FakeModel(rec)

--- a/tests/test_decode_stream_sync.py
+++ b/tests/test_decode_stream_sync.py
@@ -98,7 +98,9 @@ def recorded_fixture(monkeypatch: pytest.MonkeyPatch) -> _Recorder:
             current_stream = producer
             rec.events.append(f"exit({stream.name})")
 
-    monkeypatch.setattr(model_module.torch.cuda, "current_stream", lambda: current_stream)
+    monkeypatch.setattr(
+        model_module.torch.cuda, "current_stream", lambda: current_stream
+    )
     monkeypatch.setattr(model_module.torch.cuda, "stream", fake_stream_ctx)
 
     fake = _FakeModel(rec)

--- a/tests/test_decode_stream_sync.py
+++ b/tests/test_decode_stream_sync.py
@@ -1,0 +1,142 @@
+"""The mel must be synchronised onto the decode stream before the encoder runs.
+
+``_audio_to_mel`` builds the mel on whichever stream the caller is using;
+``_decode_mel`` then switches to ``self.stream`` and feeds it to the encoder.
+Entering a stream context does *not* synchronise the two, so without an explicit
+wait the encoder could read the mel while its producing kernels were still in
+flight -- yielding a subtly wrong spectrogram and, from it, a confident silence
+token. Measured on an RTX 4080: 126 of 2400 transcriptions of clean speech came
+back as '.', '[ Silence ]' or '[no audio]'; with the wait, 0 of 2400. Both
+decoders were affected, since both route through ``_decode_mel``.
+
+The race itself is timing-dependent and cannot be reproduced deterministically,
+so what is pinned here is the ordering contract that removes it: the decode
+stream waits on the producing stream, and the mel is marked live on the decode
+stream, both *before* the encoder is invoked. Ordering is the whole point -- a
+wait issued after ``embed_audio`` would satisfy a naive "was it called?" check
+while fixing nothing.
+
+Runs without a GPU: the streams and the mel are stand-ins that record what was
+called on them, in order.
+"""
+
+from contextlib import contextmanager
+from typing import Any
+
+import pytest
+
+model_module = pytest.importorskip(
+    "whisper_trt.model", reason="whisper_trt requires torch/tensorrt"
+)
+
+
+class _Recorder:
+    """Shared, ordered log of the calls the contract cares about."""
+
+    def __init__(self) -> None:
+        self.events: list[str] = []
+
+
+class _FakeStream:
+    def __init__(self, name: str, rec: _Recorder) -> None:
+        self.name = name
+        self._rec = rec
+
+    def wait_stream(self, other: "_FakeStream") -> None:
+        self._rec.events.append(f"{self.name}.wait_stream({other.name})")
+
+
+class _FakeMel:
+    def __init__(self, rec: _Recorder) -> None:
+        self._rec = rec
+
+    def record_stream(self, stream: _FakeStream) -> None:
+        self._rec.events.append(f"mel.record_stream({stream.name})")
+
+
+class _FakeModel:
+    """The minimum surface ``_decode_mel`` touches, all of it recording."""
+
+    def __init__(self, rec: _Recorder) -> None:
+        self._rec = rec
+        self.stream = _FakeStream("decode", rec)
+        self.dims = type("Dims", (), {"n_text_ctx": 8})()
+
+    def embed_audio(self, mel: Any) -> str:
+        self._rec.events.append("embed_audio")
+        return "audio_features"
+
+    def _get_tokenizer(self) -> str:
+        return "tokenizer"
+
+    def _configure_tokenizer(self, tokenizer: Any, language: str) -> None:
+        return None
+
+    def _prepare_prompt_tokens(self, *args: Any, **kwargs: Any) -> tuple:
+        return ("out_tokens", 1, 1)
+
+    def _decode_sequence(self, tokenizer: Any, request: Any) -> tuple:
+        self._rec.events.append("decode_sequence")
+        return ("text", [], 0.0)
+
+
+@pytest.fixture(name="recorded")
+def recorded_fixture(monkeypatch: pytest.MonkeyPatch) -> _Recorder:
+    """Run ``_decode_mel`` against fakes and return the ordered call log."""
+    rec = _Recorder()
+    producer = _FakeStream("producer", rec)
+
+    @contextmanager
+    def fake_stream_ctx(stream: _FakeStream):
+        rec.events.append(f"enter({stream.name})")
+        yield
+        rec.events.append(f"exit({stream.name})")
+
+    monkeypatch.setattr(
+        model_module.torch.cuda, "current_stream", lambda: producer
+    )
+    monkeypatch.setattr(model_module.torch.cuda, "stream", fake_stream_ctx)
+
+    fake = _FakeModel(rec)
+    model_module.WhisperTRT._decode_mel(
+        fake,
+        _FakeMel(rec),
+        language="en",
+        stream=False,
+        initial_prompt=None,
+    )
+    return rec
+
+
+def test_decode_stream_waits_on_the_producing_stream(recorded: _Recorder) -> None:
+    """The mel's producer must be waited on, not merely switched away from."""
+    assert "decode.wait_stream(producer)" in recorded.events
+
+
+def test_mel_is_marked_live_on_the_decode_stream(recorded: _Recorder) -> None:
+    """Without this the allocator may reissue the mel mid-encode."""
+    assert "mel.record_stream(decode)" in recorded.events
+
+
+def test_sync_happens_before_the_encoder_reads_the_mel(
+    recorded: _Recorder,
+) -> None:
+    """The ordering *is* the fix; a late wait would be no fix at all."""
+    events = recorded.events
+    assert "embed_audio" in events, "encoder was never invoked"
+    encoder = events.index("embed_audio")
+    assert events.index("decode.wait_stream(producer)") < encoder
+    assert events.index("mel.record_stream(decode)") < encoder
+
+
+def test_wait_is_taken_on_the_stream_actually_in_use(
+    recorded: _Recorder,
+) -> None:
+    """Guards the subtle trap: inside the context ``current_stream()`` is
+    already the decode stream, so capturing the producer *after* entering
+    would make the wait a self-wait and silently do nothing."""
+    events = recorded.events
+    assert events.index("decode.wait_stream(producer)") > events.index(
+        "enter(decode)"
+    )
+    assert "decode.wait_stream(decode)" not in events

--- a/tests/test_decode_stream_sync.py
+++ b/tests/test_decode_stream_sync.py
@@ -92,9 +92,7 @@ def recorded_fixture(monkeypatch: pytest.MonkeyPatch) -> _Recorder:
         yield
         rec.events.append(f"exit({stream.name})")
 
-    monkeypatch.setattr(
-        model_module.torch.cuda, "current_stream", lambda: producer
-    )
+    monkeypatch.setattr(model_module.torch.cuda, "current_stream", lambda: producer)
     monkeypatch.setattr(model_module.torch.cuda, "stream", fake_stream_ctx)
 
     fake = _FakeModel(rec)
@@ -136,7 +134,5 @@ def test_wait_is_taken_on_the_stream_actually_in_use(
     already the decode stream, so capturing the producer *after* entering
     would make the wait a self-wait and silently do nothing."""
     events = recorded.events
-    assert events.index("decode.wait_stream(producer)") > events.index(
-        "enter(decode)"
-    )
+    assert events.index("decode.wait_stream(producer)") > events.index("enter(decode)")
     assert "decode.wait_stream(decode)" not in events

--- a/whisper_trt/model.py
+++ b/whisper_trt/model.py
@@ -715,7 +715,20 @@ class WhisperTRT(nn.Module):
     ) -> tuple[str, list[str], float]:
         """Decode a mel tensor into final text and optional transcript chunks."""
         max_len = self.dims.n_text_ctx + 1
+        # ``mel`` was produced on the caller's stream. Entering a stream context
+        # does not synchronise, so without this wait the encoder can start on
+        # self.stream while the mel's kernels are still in flight and read the
+        # buffer a kernel short of complete. It decodes to a silence token --
+        # measured at 126/2400 transcriptions of clean speech coming back as
+        # '.', '[ Silence ]' or '[no audio]' across tiny/base/small, and 0/2400
+        # with this wait in place.
+        producer = torch.cuda.current_stream()
         with torch.cuda.stream(self.stream):
+            self.stream.wait_stream(producer)
+            # The mel was allocated against ``producer``; tell the allocator it
+            # is live on self.stream too, or it can be handed out again while
+            # the encoder is still reading it.
+            mel.record_stream(self.stream)
             audio_features = self.embed_audio(mel)
             tokenizer = self._get_tokenizer()
             self._configure_tokenizer(tokenizer, language)


### PR DESCRIPTION
`_audio_to_mel` builds the mel on the caller's stream; `_decode_mel` then switches to `self.stream` and hands it straight to the encoder. Entering a stream context does not synchronise the two, so the encoder could begin while the mel's kernels were still in flight and read the buffer a kernel short of complete. The spectrogram is then subtly wrong and Whisper confidently decodes it as a silence token.

That surfaced as intermittent, unreproducible reports of clean speech coming back as '.', '[ Silence ]' or '[no audio]'. Measured on an RTX 4080 across tiny/base/small in FP16, both the dynamic and the CUDA-graph decoder: 126 of 2400 transcriptions were wrong, and 0 of 2400 with this wait in place.

`record_stream` covers the second half of the hand-off: the mel is allocated against the producing stream, so without it the caching allocator may reissue those blocks while the encoder is still reading them.

Distinct from the use-after-free fixed in #1048, which made the *same* mel -> encoder hand-off return deterministically wrong output. That one was about buffer lifetime, this one about ordering; neither subsumes the other. The tests pin the ordering rather than the race, which is not deterministically reproducible: capturing the producer stream after entering the context would make the wait a self-wait and silently fix nothing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved GPU stream synchronization during audio decoding.
  - Prevented decoding from reading incomplete audio features, reducing the risk of incorrect silence results.
  - Ensured audio data remains available until encoding finishes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->