### PR TITLE
fix(int8): keep residual adds and layer norms out of INT8

### DIFF
--- a/whisper_trt/model.py
+++ b/whisper_trt/model.py
@@ -1248,9 +1248,27 @@ class WhisperTRTBuilder:
                 input_names=["x", "positional_embedding"],
                 output_names=["output"],
                 max_workspace_size=cls._effective_workspace(),
-                # Everything the Q/DQ pairs don't cover (attention matmuls,
-                # layer norms, softmax) is cast to FP16 in the same quantizer
-                # pass, so an int8 encoder is INT8-where-quantized, FP16 else.
+                # Keep the residual adds and layer norms out of INT8. They
+                # carry the accumulated activations, whose outliers set an
+                # enormous per-tensor range -- the worst scale measured was
+                # 4.35, i.e. a span of ~553 squeezed into 256 levels -- and
+                # quantizing them is what destroys the encoder. Measured on
+                # base, encoder features against the FP16 engine:
+                #
+                #   quantize everything        cosine 0.61  -> "" / "music"
+                #   without Add + LayerNorm    cosine 0.98  -> correct text
+                #
+                # They cost nearly nothing to leave in FP16 (elementwise, not
+                # the compute), so the MatMuls carrying the INT8 win stay
+                # quantized. Conv adds ~0.001 and is left in.
+                #
+                # ModelOpt already keeps the attention BMMs out on its own
+                # (only weight-bearing MatMuls get Q/DQ), so they need no entry
+                # here -- and excluding them explicitly changes nothing.
+                int8_op_block_list=("Add", "LayerNormalization"),
+                # Everything left unquantized is cast to FP16 in the same
+                # quantizer pass, so an int8 encoder is INT8-where-quantized,
+                # FP16 elsewhere.
                 fp16_mode=cls.fp16_mode or int8_mode,
                 log_level=_trt_log_level(cls.verbose),
             )


### PR DESCRIPTION
The INT8 encoder did not work. It first died during calibration, and once that was fixed it built an engine whose features barely resembled the FP16 ones (cosine 0.61) and which transcribed clean speech as "" or "music".

Two independent causes.

Calibration crashed because ModelOpt derives its iteration count from only the first graph input and infers that input's shape with dynamic dims filled in as
1. positional_embedding carries no batch axis, so six calibration items concatenate to (9000, 512) against an inferred leading dim of 1, and the count came out 9000 instead of 6 -- after six real batches the calibrator was handed empty ones. Fixed in torch2trt (calibration_shapes_spec), bumped here.

The accuracy loss was quantizing the residual adds. They carry the accumulated activations, whose outliers set an enormous per-tensor range: the worst scale measured was 4.35, a span of ~553 squeezed into 256 levels. Measured on base, encoder features against the FP16 engine:

  quantize everything                cosine 0.61   "" / "music"
  without Add                        cosine 0.91
  without Add + LayerNormalization   cosine 0.98   correct transcript

Adds and layer norms are elementwise, not the compute, so leaving them in FP16 costs nearly nothing while the MatMuls that carry the INT8 win stay quantized. Conv is worth ~0.001 and is left quantized.

Also corrects the comment above: ModelOpt already keeps the attention BMMs unquantized on its own -- only weight-bearing MatMuls get Q/DQ -- so they were never the problem, and excluding them explicitly changes nothing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved INT8 audio-encoder conversion by selectively quantizing supported compute-intensive operations.
  * Preserved FP16 processing for operations that are not suitable for INT8 quantization, improving conversion compatibility and stability.
* **Maintenance**
  * Updated the bundled torch2trt integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->