### PR TITLE
ci: run the tests, and assert the server loaded what it was told to

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -57,7 +57,7 @@ jobs:
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v7
+      uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
 
     # Add any setup steps before running the `github/codeql-action/init` action.
     # This includes steps like installing compilers or runtimes (`actions/setup-node`
@@ -67,7 +67,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
@@ -96,6 +96,6 @@ jobs:
         exit 1
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/publish_container.yaml
+++ b/.github/workflows/publish_container.yaml
@@ -123,7 +123,12 @@ jobs:
           context: .
           file: ./Dockerfile.igpu
           tags: ${{ steps.prepare-igpu-tags.outputs.igpu_tags }}
-          labels: ${{ steps.meta.outputs.labels }}-igpu
+          # The same labels as the dGPU image, deliberately. This was
+          # '${{ steps.meta.outputs.labels }}-igpu', but that output is a
+          # newline-separated list of key=value pairs, so the suffix landed on
+          # the value of whichever label came last rather than marking the
+          # image. The '-igpu' tag is what distinguishes these builds.
+          labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/arm64
           # zstd layers; see the note on the dGPU step above.
           outputs: type=image,push=true,compression=zstd,compression-level=3,force-compression=true

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -15,14 +15,14 @@ jobs:
           token: ${{ secrets.CI_PUSH_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Ruff Check (Auto-fix)
-        uses: astral-sh/ruff-action@v4.1.0
+        uses: astral-sh/ruff-action@278981a28ce3188b1e39527901f38254bf3aac89 # v4.1.0
         with:
           version: "0.15.10"
           src: "."
           args: "check --fix"
 
       - name: Ruff Format (Auto-fix)
-        uses: astral-sh/ruff-action@v4.1.0
+        uses: astral-sh/ruff-action@278981a28ce3188b1e39527901f38254bf3aac89 # v4.1.0
         with:
           version: "0.15.10"
           src: "."

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,21 +1,94 @@
 name: Test Whisper TRT ASR Server
 permissions:
   contents: read
-  pull-requests: write
 
 on:
   pull_request:
     branches: [ main ]
+    # Deliberately short. 'tests/**' used to be ignored, which meant a PR that
+    # only touched tests ran no tests at all; '.github/**' was ignored, which
+    # meant a change to this file could not be validated by this file.
     paths-ignore:
-      - '.github/**'
       - '.vscode/**'
       - 'examples/**'
-      - 'tests/**'
       - '**/*.md'
       - 'renovate.json'
+  push:
+    branches: [ main ]
+
+# Superseded runs are cancelled so the single self-hosted GPU runner is not
+# working through a queue of commits nobody is waiting on. Scoped per PR, so
+# concurrent PRs still queue rather than cancel each other.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  # Add a dependency job that waits for required checks
+  # The fast gate: the whole suite minus the GPU-marked tests, on a hosted
+  # runner, against the pinned requirements. Fails the PR before the expensive
+  # self-hosted job is ever queued.
+  #
+  # Both Python versions are deliberate: 3.12 is what the runtime image ships
+  # (the Dockerfile's ubuntu:24.04 stage), 3.14 is what the self-hosted job
+  # installs. Testing only one of them leaves the other shipping untested.
+  unit_tests:
+    name: "Unit tests (Python ${{ matrix.python-version }})"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.12', '3.14']
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+        with:
+          # tests/test_quant.py imports torch2trt's precision module straight
+          # from the checkout when it is not installed, so the submodule has to
+          # be present even though nothing is built here.
+          submodules: recursive
+
+      # The pinned requirements pull CUDA-enabled torch plus the NVIDIA CUDA,
+      # cuDNN and TensorRT wheels: roughly 8 GB installed, against a hosted
+      # runner that starts with about half that free. Removing toolchains this
+      # job will never use buys back ~25 GB. Done inline rather than through a
+      # third-party action so no new code is trusted with the runner.
+      - name: Free disk space
+        shell: bash
+        run: |
+          df -h /
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+                      /usr/local/.ghcup /opt/hostedtoolcache/CodeQL \
+                      /usr/local/share/powershell /usr/share/swift || true
+          df -h /
+
+      - name: Setup Python
+        uses: actions/setup-python@28f2168f4d98ee0445e3c6321f6e6616c83dd5ec
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Cache pip downloads
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ~/.cache/pip
+          key: pip-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('requirements.txt', 'requirements_dev.txt') }}
+          restore-keys: |
+            pip-${{ runner.os }}-${{ matrix.python-version }}-
+
+      # The same script the Dockerfile runs, so an install that breaks in the
+      # image breaks here first. It needs no CUDA toolkit: torch2trt's nvcc
+      # extension is opt-in behind --plugins, which script/setup does not pass.
+      - name: Setup Virtual Environment
+        shell: bash
+        run: |
+          chmod +x script/setup
+          ./script/setup --dev
+
+      # No GPU here, so the CUDA-marked tests skip. -ra prints the skip reasons,
+      # which is how a test that silently stopped running gets noticed.
+      - name: Run tests
+        shell: bash
+        run: .venv/bin/python -m pytest tests -v -ra
+
   wait_for_checks:
     name: "Wait for required checks"
     runs-on: ubuntu-latest
@@ -33,7 +106,14 @@ jobs:
   test_linux:
     name: "Build and Test on Linux (self-hosted runner)"
     runs-on: self-hosted
-    needs: wait_for_checks
+    needs: [unit_tests, wait_for_checks]
+    # Never run a fork's code on the self-hosted runner. pip executes arbitrary
+    # build code during install, so a fork PR that repoints requirements.txt at
+    # a hostile sdist is code execution on the runner; the read-only token a
+    # fork PR gets does not help with that.
+    if: >-
+      github.event_name == 'push' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     steps:
       # 1. Checkout the repository code
       - name: Checkout Code
@@ -45,104 +125,89 @@ jobs:
       # image (local/gpu-runner), so no in-job apt/pip installs are needed.
 
       # Setup Python. RUNNER_TOOL_CACHE points at the persistent NFS cache on
-      # the runner, so 3.13 is downloaded once and restored instantly after.
+      # the runner, so 3.14 is downloaded once and restored instantly after.
       - name: Setup Python
         uses: actions/setup-python@28f2168f4d98ee0445e3c6321f6e6616c83dd5ec
         with:
-          python-version: '3.14'  # Use a stable version
+          python-version: '3.14'
 
-      # CUDA toolkit IS required here: torch2trt/setup.py builds a CUDAExtension
-      # ('plugins') via nvcc, which needs CUDA_HOME. (glados can drop it because
-      # it uses the torch-tensorrt wheel; whisper compiles torch2trt.) The GPU
-      # driver comes from the runner's nvidia runtime; the installer is cached
-      # in GitHub cache + the persistent runner tool cache. CUDA_HOME is set
-      # explicitly so torch's cpp_extension finds it.
-      - name: Install CUDA Toolkit
-        uses: Jimver/cuda-toolkit@3d45d157f327c09c04b50ee6ccdea2d9d017ec76
-        with:
-          # GitHub Actions cache is scoped per-branch, so on a self-hosted runner
-          # it misses on nearly every PR and re-downloads the ~4GB installer over
-          # the network. Disable it and rely only on the local tool cache, which
-          # lives on the runner's persistent NFS RUNNER_TOOL_CACHE and always hits
-          # after the first install.
-          use-github-cache: false
-          use-local-cache: true
-
-      # 6. Create and activate virtual environment (torch2trt compiles here)
+      # 2. Create the virtual environment.
+      #
+      # No CUDA toolkit step: torch2trt's only nvcc-built extension ('plugins')
+      # is opt-in behind --plugins, which script/setup does not pass, so the
+      # install is pure Python. This job used to download a ~4 GB CUDA installer
+      # for a compile that no longer happens. The GPU driver comes from the
+      # runner's nvidia runtime, and torch and tensorrt ship their own CUDA
+      # libraries as wheels.
       - name: Setup Virtual Environment
         shell: bash
-        env:
-          # Jimver exports CUDA_PATH; torch2trt's CUDAExtension needs CUDA_HOME.
-          CUDA_HOME: ${{ env.CUDA_PATH }}
         run: |
           chmod +x script/setup
-          ./script/setup
+          ./script/setup --dev
 
-      # 7. Start server and test listening
-      - name: Start server and test listening
+      # 3. Resolve the persistent engine/model cache used by the steps below.
+      #
+      # The runner pool has mixed GPUs (e.g. sm_89 RTX 4070 Ti and sm_86 RTX
+      # 3050) and TRT engine plans are architecture specific. The engine
+      # checkpoint filename carries the compute capability of the device torch
+      # selects, so runners of different archs can share these dirs without one
+      # deserializing the other's plan (TRT "incompatible device" error 6).
+      - name: Resolve cache directories
         shell: bash
         run: |
-          # Activate the virtual environment
+          if [ -n "${RUNNER_CACHE:-}" ]; then
+            echo "DATA_DIR=$RUNNER_CACHE/whisper/data" >> "$GITHUB_ENV"
+            echo "DOWNLOAD_DIR=$RUNNER_CACHE/whisper/download" >> "$GITHUB_ENV"
+          else
+            echo "DATA_DIR=$PWD/data" >> "$GITHUB_ENV"
+            echo "DOWNLOAD_DIR=$PWD/download" >> "$GITHUB_ENV"
+          fi
+
+      # 4. The acceptance test. tests/test_wyoming_whisper_trt.py starts the
+      # real server over TCP and asserts the exact transcript of a known WAV,
+      # across float16/int8 and both decoder modes. It is skipped everywhere
+      # without a GPU, which is to say it had never run anywhere. This is the
+      # step that proves transcription works, as opposed to proving a port
+      # opened.
+      - name: Run tests (including GPU-only)
+        shell: bash
+        env:
+          # Build engines into the persistent cache; a cold int8 build is
+          # minutes, and the repo checkout is discarded after every run.
+          WHISPER_TRT_TEST_DATA_DIR: ${{ env.DATA_DIR }}
+        run: |
+          mkdir -p "$WHISPER_TRT_TEST_DATA_DIR"
+          .venv/bin/python -m pytest tests -v -ra
+
+      # 5. Start the server exactly as the container does, and assert what it
+      # actually loaded.
+      - name: Start server and assert acceleration
+        shell: bash
+        run: |
+          set -uo pipefail
           source .venv/bin/activate
 
-          # Define server URI for testing
-          TEST_URI="tcp://127.0.0.1:8080"
-
-          # Data and model download dirs. Point them at the persistent runner
-          # cache when available so the expensive TRT engine build + model
-          # download are reused across runs; fall back to local dirs on runners
-          # without the cache mount.
-          #
-          # The runner pool has mixed GPUs (e.g. sm_89 RTX 4070 Ti and sm_86 RTX
-          # 3050) and TRT engine plans are architecture specific. The engine
-          # checkpoint lands in --download-dir, and its filename now carries the
-          # compute capability of the device torch selects, so runners of
-          # different archs can share these dirs without one deserializing the
-          # other's plan (TRT "incompatible device" error 6).
-          if [ -n "$RUNNER_CACHE" ]; then
-            DATA_DIR="$RUNNER_CACHE/whisper/data"
-            DOWNLOAD_DIR="$RUNNER_CACHE/whisper/download"
-          else
-            DATA_DIR="./data"
-            DOWNLOAD_DIR="./download"
-          fi
+          mkdir -p "$DATA_DIR" "$DOWNLOAD_DIR"
           echo "Using DATA_DIR=$DATA_DIR DOWNLOAD_DIR=$DOWNLOAD_DIR"
 
-          # Create necessary directories
-          mkdir -p $DATA_DIR
-          mkdir -p $DOWNLOAD_DIR
-
-          # Start the server in the background, redirecting output to server.log
-          # CI smoke test only needs to prove the server loads a model, builds
-          # its TRT engine, and listens. Use base.en (English-only, ~74M): far
-          # less VRAM/RAM and a much faster engine build than medium (~769M),
-          # which was OOMing against the runner memory limit. --language en
-          # matches the English-only model (auto detection doesn't apply).
+          # base.en (English-only, ~74M): far less VRAM and a much faster engine
+          # build than medium (~769M), which was OOMing against the runner
+          # memory limit. --language en matches the English-only model.
           nohup python -m wyoming_whisper_trt.__main__ \
             --model base.en \
-            --uri $TEST_URI \
-            --data-dir $DATA_DIR \
-            --download-dir $DOWNLOAD_DIR \
+            --uri tcp://127.0.0.1:8080 \
+            --data-dir "$DATA_DIR" \
+            --download-dir "$DOWNLOAD_DIR" \
             --compute-type float16 \
             --language en \
             > server.log 2>&1 &
-        
-          # Capture the server's Process ID (PID)
           SERVER_PID=$!
           echo "Started Whisper TRT server with PID $SERVER_PID"
 
-          # Function to check if the server is listening on port 8080
-          function is_server_listening() {
-            nc -z localhost 8080
-          }
-
-          # Initialize timeout parameters
-          TIMEOUT=600      # Maximum time to wait for the server to start (in seconds)
-          INTERVAL=10      # Interval between each check (in seconds)
+          TIMEOUT=600
+          INTERVAL=10
           ELAPSED=0
-
-          # Loop to check if the server is listening
-          while ! is_server_listening; do
+          while ! nc -z localhost 8080; do
             # Fail fast if the server process died (e.g. a native segfault)
             # instead of waiting out the full timeout.
             if ! kill -0 "$SERVER_PID" 2>/dev/null; then
@@ -153,29 +218,77 @@ jobs:
               cat server.log || true
               exit 1
             fi
-            if [ $ELAPSED -ge $TIMEOUT ]; then
+            if [ "$ELAPSED" -ge "$TIMEOUT" ]; then
               echo "Server failed to start within $TIMEOUT seconds."
               kill "$SERVER_PID" 2>/dev/null || true
+              cat server.log || true
               exit 1
             fi
             echo "Waiting for server to start... ($ELAPSED/$TIMEOUT seconds elapsed)"
-            sleep $INTERVAL
+            sleep "$INTERVAL"
             ELAPSED=$((ELAPSED + INTERVAL))
           done
+          echo "Server is listening on port 8080."
 
-          echo "Server is successfully listening on port 8080."
+          kill "$SERVER_PID" 2>/dev/null || true
+          wait "$SERVER_PID" 2>/dev/null || true
 
-          # Terminate the server gracefully
-          kill $SERVER_PID
-          wait $SERVER_PID 2>/dev/null || true
+          # Listening proves the process started, not that it started the way it
+          # was asked to. The server logs one line naming what it actually
+          # loaded; each assertion below covers a setting that can diverge from
+          # the flags above without the process ever failing.
+          echo "----- runtime configuration -----"
+          if ! grep -F "whisper-trt runtime:" server.log; then
+            echo "::error::Server never logged its runtime configuration."
+            cat server.log
+            exit 1
+          fi
 
-          # Exit the step with success
-          exit 0
+          FAILED=0
+          assert_log() {
+            if grep -Eq "$1" server.log; then
+              echo "ok: $2"
+            else
+              echo "::error::$2"
+              FAILED=1
+            fi
+          }
 
-      # 8. Upload server logs (always upload logs regardless of success or failure)
+          # What was asked for on the command line.
+          assert_log 'whisper-trt runtime:.*[[:space:]]model=base\.en[[:space:]]' \
+            'model is base.en'
+          assert_log 'whisper-trt runtime:.*[[:space:]]compute_type=float16[[:space:]]' \
+            'compute type is float16, not a silently downgraded engine'
+          assert_log 'whisper-trt runtime:.*[[:space:]]language=en[[:space:]]' \
+            'language is en'
+
+          # That the acceleration is real. arch=smunknown and device='cpu' are
+          # what this line reports when torch found no CUDA device, which is the
+          # shape a silent fallback to CPU would take.
+          assert_log 'whisper-trt runtime:.*[[:space:]]arch=sm[0-9]+[[:space:]]' \
+            'a CUDA device was selected (arch is not smunknown)'
+          assert_log "whisper-trt runtime:.*device='[^']*[Nn][Vv][Ii][Dd][Ii][Aa][^']*'" \
+            'torch reports an NVIDIA device'
+          assert_log 'whisper-trt runtime:.*[[:space:]]tensorrt=[0-9]+\.' \
+            'TensorRT is loaded and reports a version'
+          assert_log 'whisper-trt runtime:.*[[:space:]]cuda=[0-9]+\.' \
+            'torch was built against CUDA'
+
+          if grep -q "Traceback (most recent call last)" server.log; then
+            echo "::error::Server logged a traceback during startup."
+            FAILED=1
+          fi
+
+          if [ "$FAILED" -ne 0 ]; then
+            echo "----- server.log -----"
+            cat server.log
+            exit 1
+          fi
+
+      # 6. Upload server logs (always, regardless of outcome)
       - name: Upload server logs
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
         with:
           name: server-logs
           path: server.log
-        if: always()  # This ensures the step runs even if previous steps fail
+        if: always()

--- a/Dockerfile
+++ b/Dockerfile
@@ -96,7 +96,12 @@ RUN set -eu; \
         echo "The runtime python minor version must match the NGC builder's." >&2; \
         exit 1; \
     fi; \
-    "$py" -c 'import torch, wyoming_whisper_trt'
+    # Beyond "does it import": pip can resolve a CPU-only torch, and tensorrt
+    # can install as a wheel whose libraries never load. Either produces an
+    # image that starts, listens, accepts audio and quietly transcribes on the
+    # CPU. Assert both here, at build time, instead of discovering it as a
+    # mysteriously slow container.
+    "$py" -c 'import tensorrt, torch, wyoming_whisper_trt; assert torch.version.cuda, "torch has no CUDA build: " + torch.__version__; print("verified: torch", torch.__version__, "cuda", torch.version.cuda, "tensorrt", tensorrt.__version__)'
 
 WORKDIR /
 COPY ./run.sh ./

--- a/tests/test_wyoming_whisper_trt.py
+++ b/tests/test_wyoming_whisper_trt.py
@@ -10,6 +10,7 @@ compute type.
 
 import asyncio
 import io
+import os
 import re
 import socket
 import sys
@@ -33,7 +34,10 @@ _CUDA_AVAILABLE = torch.cuda.is_available()
 
 _DIR = Path(__file__).parent
 _PROGRAM_DIR = _DIR.parent
-_LOCAL_DIR = _PROGRAM_DIR / "local"
+# The engine cache these tests build into. Overridable because a cold build is
+# minutes (longer for int8, which calibrates), and CI runners keep a persistent
+# cache mount: pointing this there pays the build once instead of every run.
+_LOCAL_DIR = Path(os.environ.get("WHISPER_TRT_TEST_DATA_DIR") or _PROGRAM_DIR / "local")
 _SAMPLES_PER_CHUNK = 1024
 # Generous: covers a cold TensorRT engine build before the port opens.
 _STARTUP_TIMEOUT = 600

--- a/wyoming_whisper_trt/__main__.py
+++ b/wyoming_whisper_trt/__main__.py
@@ -20,6 +20,8 @@ from functools import partial
 from pathlib import Path
 from typing import Any
 
+import tensorrt
+import torch
 from whisper.model import disable_sdpa
 from wyoming.info import AsrModel, AsrProgram, Attribution, Info
 from wyoming.server import AsyncServer
@@ -28,7 +30,9 @@ from whisper_trt import (
     WhisperTRT,
     WhisperTRTBuilder,
     auto_workspace_mb,
+    get_device_arch_tag,
     get_model_filename,
+    get_trt_version_tag,
     int8_available,
     load_trt_model,
 )
@@ -223,6 +227,44 @@ async def run_server(
         # Use the stop method to handle event handler shutdown and server closure
         await server.stop()
         logger.info("Server and event handlers stopped gracefully.")
+
+
+def _log_runtime_configuration(model_name: str, language: str) -> None:
+    """Emit one line naming what actually got loaded.
+
+    Every field here is something the process can end up running with *other*
+    than what was asked for, and each has a silent-degradation path: an engine
+    restored from a checkpoint built under different settings, a decoder that
+    fell back, a language tag that does not match an English-only model. Where
+    a config value and the loaded reality can diverge, this reports the loaded
+    reality.
+
+    Deliberately one greppable line at INFO, rather than the DEBUG lines that
+    carry the same facts, because CI asserts on it: a smoke test that only
+    proves the process listens on a port cannot tell a working TensorRT engine
+    from a degraded one, and nothing can be asserted that is not printed.
+    """
+    try:
+        device_name = (
+            torch.cuda.get_device_name() if torch.cuda.is_available() else "cpu"
+        )
+    except (RuntimeError, AssertionError):  # pragma: no cover - driver dependent
+        device_name = "unknown"
+
+    logger.info(
+        "whisper-trt runtime: model=%s compute_type=%s decoder=%s language=%s "
+        "device='%s' arch=%s tensorrt=%s (tag %s) torch=%s cuda=%s",
+        model_name,
+        WhisperTRTBuilder.get_compute_type(),
+        WhisperTRTBuilder.decoder_mode,
+        language,
+        device_name,
+        get_device_arch_tag(),
+        tensorrt.__version__,
+        get_trt_version_tag(),
+        torch.__version__,
+        torch.version.cuda,
+    )
 
 
 def _apply_compute_type(compute_type: str) -> None:
@@ -500,6 +542,7 @@ async def main() -> None:
             language=args.language,
         )
         logger.info("Whisper TRT model '%s' loaded successfully.", model_name)
+        _log_runtime_configuration(model_name, args.language)
     except (KeyError, RuntimeError, OSError, ValueError) as err:
         logger.error("Failed to load Whisper TRT model '%s': %s", model_name, err)
         sys.exit(1)


### PR DESCRIPTION
No workflow ran the test suite. The only test-shaped job started the server and checked that port 8080 accepted a connection; it never imported a test module, and 'tests/**' sat in paths-ignore, so a PR that changed nothing but tests ran nothing at all. 74 tests passed locally the whole time.

Among them, tests/test_wyoming_whisper_trt.py starts the real server over TCP and asserts the exact transcript of a known WAV across float16, int8 and both decoder modes. It is gated on a CUDA device, so it had never run anywhere -- the acceptance test for this project's entire purpose.

- unit_tests: hosted runner, the pinned requirements, Python 3.12 and 3.14. 3.12 is what the runtime image ships and 3.14 is what the self-hosted job installs; testing one left the other shipping untested. Gates the GPU job.
- test_linux now runs pytest, which unskips the GPU-marked tests, with the engine cache pointed at the runner's persistent mount so a cold int8 build is paid once (hence WHISPER_TRT_TEST_DATA_DIR).

Listening also does not prove the server started the way it was asked to. The compute type, the model, the language and the device are each free to diverge from the flags without the process ever failing, so the server now logs one line naming what it actually loaded, and CI asserts on it -- notably that arch is not 'smunknown' and the device is not 'cpu', which is the shape a silent fall back to CPU takes. Verified the assertions fail against a CPU-fallback log and a downgraded-precision log, not just pass against a good one.

Also:
- Drop the CUDA toolkit step. torch2trt's only nvcc-built extension is opt-in behind --plugins, which script/setup does not pass, so this downloaded a ~4 GB installer for a compile that no longer happens.
- Guard the self-hosted job on the PR coming from this repo. pip runs arbitrary build code during install, so a fork PR repointing requirements.txt at a hostile sdist was code execution on the runner.
- Add a per-PR concurrency group so superseded commits stop queueing behind the single GPU runner.
- Assert at image build time that torch has a CUDA build and tensorrt imports; a CPU-only torch resolved by pip yields an image that starts, listens and quietly transcribes on the CPU.
- Pin the remaining actions by SHA (ruff-action, codeql-action, checkout).
- publish_container: '${{ steps.meta.outputs.labels }}-igpu' appended the suffix to the value of whichever label came last, since that output is a newline-separated list. The '-igpu' tag is what distinguishes the builds.