### PR TITLE
chore(types): put the tests under ty as well

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,9 +103,10 @@ skip-magic-trailing-comma = false
 line-ending = "auto"
 
 [tool.ty.src]
-# Matches the include pyright used, so this is a like-for-like swap. Tests
-# are checked by neither; widening the scope is its own change.
-include = ["wyoming_whisper_trt", "whisper_trt"]
+# Wider than the include pyright used, which was the two packages: tests had
+# never been type checked by anything. Adding them reported seven findings,
+# none of them noise.
+include = ["wyoming_whisper_trt", "whisper_trt", "tests"]
 exclude = ["torch2trt", "**/__pycache__"]
 
 [tool.ty.environment]

--- a/tests/test_shared_device_memory.py
+++ b/tests/test_shared_device_memory.py
@@ -96,17 +96,23 @@ class _FakeEngine:
 
     ``routes`` names which context-creation spellings this TensorRT provides:
     "config" (11.x and 10.x), "strategy" (10.x), "legacy" (pre-10, removed in
-    11.0), or none at all.
+    11.0), or none at all. ``refuse_context`` is the other failure TensorRT can
+    hand back: a route that exists and returns nothing.
     """
 
     def __init__(
-        self, nbytes: int, routes: tuple[str, ...] = ("config",), v2: bool = False
+        self,
+        nbytes: int,
+        routes: tuple[str, ...] = ("config",),
+        v2: bool = False,
+        refuse_context: bool = False,
     ) -> None:
         self.device_memory_size_v2 = nbytes
         self.device_memory_size = nbytes
         self.context = _FakeContext(v2=v2)
         self.route_used: str | None = None
         self._routes = routes
+        self._refuse_context = refuse_context
         self.runtime_config: _FakeRuntimeConfig | None = None
         if "config" in routes:
             self.create_runtime_config = self._create_runtime_config
@@ -123,6 +129,8 @@ class _FakeEngine:
 
     def create_execution_context(self, arg: Any = None) -> _FakeContext | None:
         """Accept whichever argument shape this fake claims to support."""
+        if self._refuse_context:
+            return None
         if isinstance(arg, _FakeRuntimeConfig):
             self.route_used = "config"
             return self.context
@@ -177,8 +185,10 @@ class TestRoutes:
         assert pool.nbytes == 0
 
     def test_a_refused_context_degrades(self, pool: Any) -> None:
-        engine = _FakeEngine(1 << 20)
-        engine.create_execution_context = lambda arg=None: None
+        # A route that exists but hands back nothing. Modelled on the fake
+        # rather than by replacing the method on the instance, so what is being
+        # simulated is stated once, where the other TensorRT shapes are.
+        engine = _FakeEngine(1 << 20, refuse_context=True)
         assert pool.add(engine) is None
         assert pool.nbytes == 0
 

--- a/whisper_trt/model.py
+++ b/whisper_trt/model.py
@@ -37,7 +37,7 @@ import wave
 from collections.abc import Callable
 from dataclasses import asdict, dataclass
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, Protocol, cast
 
 import numpy as np
 import tensorrt
@@ -123,6 +123,20 @@ def _new_shared_device_memory() -> Any:
     # resolved by getattr is untyped, and calling it directly is what pylint
     # flags as not-callable.
     return _instantiate_type(pool_cls)
+
+
+class SupportsNoSpeech(Protocol):
+    """What ``WhisperTRT._is_no_speech`` actually needs of a tokenizer.
+
+    The real caller passes a whisper ``Tokenizer``, but the method reads one
+    attribute and reads it through ``getattr`` with a default, precisely so a
+    tokenizer without the token still works. Annotating the parameter as
+    ``Tokenizer`` claimed more than the body requires, and left test doubles --
+    which are the whole reason the lookup is defensive -- looking like errors.
+    """
+
+    @property
+    def no_speech(self) -> int: ...
 
 
 class IncompatibleEngineError(RuntimeError):
@@ -823,7 +837,7 @@ class WhisperTRT(nn.Module):
 
     @staticmethod
     def _is_no_speech(
-        tokenizer: Tokenizer,
+        tokenizer: SupportsNoSpeech,
         first_logits: Tensor,
         threshold: float | None,
     ) -> bool:


### PR DESCRIPTION
pyright's include was the two packages, so tests have never been type checked by anything. Widening ty to cover them reported 7 diagnostics; none were noise.

- WhisperTRT._is_no_speech never touched self and is now a staticmethod. The test had been passing None as the receiver to call it unbound, which is what three of the reports were about.

- Its tokenizer parameter is annotated SupportsNoSpeech rather than Tokenizer. The body reads exactly one attribute, through getattr with a default, precisely so a tokenizer without the token still works -- so Tokenizer claimed more than the code requires, and made the test doubles that lookup exists for look like errors.

- _FakeEngine.create_execution_context declared it returned a context while the test it exists for made it return None: the refused-context case the production code guards against. Refusal is now a constructor flag alongside the other TensorRT shapes the fake models, rather than a method replaced on the instance, so what is being simulated is stated where the rest of it is.

Checked that the reworked fake still fails against broken code: stubbing out the `if context is None` guard in trt_module.py fails test_a_refused_context_degrades and test_no_route_degrades_instead_of_raising, and restoring it passes all 16.

ruff clean, ty clean, 74 passed.