### PR TITLE
fix(decode): drop Whisper's markers by id, not by spelling

### DIFF
--- a/tests/test_decode_tokens.py
+++ b/tests/test_decode_tokens.py
@@ -1,0 +1,79 @@
+"""Whisper's special markers must not reach the transcript.
+
+No GPU and no model: this is a filter over token ids, and the real tokenizers
+load from the vocabulary files bundled with openai-whisper.
+"""
+
+import pytest
+import torch
+import whisper.tokenizer
+
+from whisper_trt.model import WhisperTRT
+
+_MULTILINGUAL = whisper.tokenizer.get_tokenizer(
+    multilingual=True, language="en", task="transcribe"
+)
+_ENGLISH_ONLY = whisper.tokenizer.get_tokenizer(multilingual=False)
+
+_TOKENIZERS = [
+    pytest.param(_MULTILINGUAL, id="multilingual"),
+    pytest.param(_ENGLISH_ONLY, id="english-only"),
+]
+
+
+def _decode(tokenizer, ids: list[int]) -> str:
+    return WhisperTRT._decode_tokens(tokenizer, torch.tensor([ids]))
+
+
+@pytest.mark.parametrize("tokenizer", _TOKENIZERS)
+def test_plain_text_survives(tokenizer) -> None:
+    ids = tokenizer.encoding.encode(" Turn on the living room lamp.")
+    assert _decode(tokenizer, ids) == "Turn on the living room lamp."
+
+
+@pytest.mark.parametrize("tokenizer", _TOKENIZERS)
+def test_the_prompt_sequence_is_dropped(tokenizer) -> None:
+    """The regression: sot and the language tag decoded as literal text.
+
+    whisper's Tokenizer.decode keeps every id below ``timestamp_begin``, and
+    that threshold is *above* the markers, so it drops none of these. `medium`
+    returned "<|startoftranscript|><|en|> Turn on the living room lamp."
+    """
+    ids = [
+        *tokenizer.sot_sequence,
+        *tokenizer.encoding.encode(" Turn on the living room lamp."),
+        tokenizer.eot,
+    ]
+    assert _decode(tokenizer, ids) == "Turn on the living room lamp."
+
+
+@pytest.mark.parametrize("tokenizer", _TOKENIZERS)
+def test_no_marker_spelling_reaches_the_transcript(tokenizer) -> None:
+    """Every id at or above eot, not the three the denylist happened to name."""
+    specials = sorted(tokenizer.special_tokens.values())
+    assert len(specials) > 3, "expected the full marker set, not a handful"
+    text = _decode(tokenizer, [*specials, *tokenizer.encoding.encode(" hello")])
+    assert text == "hello"
+    assert "<|" not in text
+
+
+@pytest.mark.parametrize("tokenizer", _TOKENIZERS)
+def test_timestamp_tokens_are_dropped(tokenizer) -> None:
+    """Above eot as well, so the id filter covers them without a second rule."""
+    ids = [
+        tokenizer.timestamp_begin,
+        *tokenizer.encoding.encode(" hello"),
+        tokenizer.timestamp_begin + 20,
+    ]
+    assert _decode(tokenizer, ids) == "hello"
+
+
+@pytest.mark.parametrize("tokenizer", _TOKENIZERS)
+def test_no_speech_marker_is_dropped(tokenizer) -> None:
+    """Sits between eot and timestamp_begin, so decode() alone keeps it."""
+    assert _decode(tokenizer, [tokenizer.no_speech]) == ""
+
+
+@pytest.mark.parametrize("tokenizer", _TOKENIZERS)
+def test_an_empty_sequence_decodes_to_empty(tokenizer) -> None:
+    assert _decode(tokenizer, [tokenizer.eot]) == ""

--- a/whisper_trt/model.py
+++ b/whisper_trt/model.py
@@ -649,7 +649,7 @@ class WhisperTRT(nn.Module):
 
             if request.stream:
                 interim = request.out_tokens[:, request.prompt_len : request.cur_len]
-                chunks.append(self._decode_tokens(interim))
+                chunks.append(self._decode_tokens(tokenizer, interim))
 
             if last_token_id == tokenizer.eot or request.cur_len >= request.max_len:
                 break
@@ -666,7 +666,7 @@ class WhisperTRT(nn.Module):
             end_index = request.cur_len - 1
 
         final_text = self._decode_tokens(
-            request.out_tokens[:, request.prompt_len : end_index]
+            tokenizer, request.out_tokens[:, request.prompt_len : end_index]
         )
         return final_text, chunks, time.perf_counter() - decode_start
 
@@ -705,7 +705,7 @@ class WhisperTRT(nn.Module):
 
             if request.stream:
                 interim = request.out_tokens[:, request.prompt_len : request.cur_len]
-                chunks.append(self._decode_tokens(interim))
+                chunks.append(self._decode_tokens(tokenizer, interim))
 
             if last_token_id == tokenizer.eot:
                 break
@@ -715,7 +715,7 @@ class WhisperTRT(nn.Module):
             end_index = request.cur_len - 1
 
         final_text = self._decode_tokens(
-            request.out_tokens[:, request.prompt_len : end_index]
+            tokenizer, request.out_tokens[:, request.prompt_len : end_index]
         )
         return final_text, chunks, time.perf_counter() - decode_start
 
@@ -749,7 +749,7 @@ class WhisperTRT(nn.Module):
 
             if request.stream:
                 interim = request.out_tokens[:, request.prompt_len : request.cur_len]
-                chunks.append(self._decode_tokens(interim))
+                chunks.append(self._decode_tokens(tokenizer, interim))
 
             if last_token_id == tokenizer.eot or request.cur_len >= request.max_len:
                 break
@@ -765,7 +765,7 @@ class WhisperTRT(nn.Module):
             end_index = request.cur_len - 1
 
         final_text = self._decode_tokens(
-            request.out_tokens[:, request.prompt_len : end_index]
+            tokenizer, request.out_tokens[:, request.prompt_len : end_index]
         )
         return final_text, chunks, time.perf_counter() - decode_start
 
@@ -928,16 +928,28 @@ class WhisperTRT(nn.Module):
         probs = torch.softmax(first_logits[0, -1, :].float(), dim=-1)
         return float(probs[no_speech_id].item()) >= threshold
 
-    def _decode_tokens(self, tokens: torch.Tensor) -> str:
-        """Decode token tensor to clean text without internal control markers."""
-        tokenizer = self._get_tokenizer()
-        text = tokenizer.decode(list(tokens.flatten().cpu().numpy()))
-        return (
-            text.replace("<|transcribe|>", "")
-            .replace("<|notimestamps|>", "")
-            .replace("<|endoftext|>", "")
-            .strip()
-        )
+    @staticmethod
+    def _decode_tokens(tokenizer: Tokenizer, tokens: torch.Tensor) -> str:
+        """Decode generated tokens to text, dropping Whisper's markers.
+
+        Filtered by id rather than by spelling. whisper's ``Tokenizer.decode``
+        keeps every id where ``t < self.timestamp_begin`` and drops the rest,
+        and ``timestamp_begin`` sits *above* every special marker -- so the only
+        thing it removes is timestamps, and ``<|startoftranscript|>``, the
+        language tag, the task tag and ``<|nospeech|>`` all survive it and land
+        in the transcript as literal text. Replacing three spellings, as this
+        did, leaves the other hundred-odd: every language tag, and the sot
+        marker itself. `medium` returned
+
+            <|startoftranscript|><|en|> Turn on the living room lamp.
+
+        ``eot`` is the lowest special id in both the multilingual and the
+        English-only vocabulary, so everything below it is transcript and
+        everything at or above it is a marker. Taking the tokenizer as an
+        argument rather than re-fetching it: every caller already has one.
+        """
+        ids = tokens.flatten().tolist()
+        return tokenizer.decode([t for t in ids if t < tokenizer.eot]).strip()
 
 
 # Whisper variants whose encoder/decoder are large enough that the default


### PR DESCRIPTION
`medium` transcribed "Turn on the living room lamp." as

    <|startoftranscript|><|en|> Turn on the living room lamp.

_decode_tokens replaced three marker spellings -- <|transcribe|>, <|notimestamps|>, <|endoftext|> -- and left every other one in the transcript, which is all 99 language tags, <|startoftranscript|>, <|nospeech|> and the rest.

The reason none of that is caught upstream: whisper's Tokenizer.decode filters `t < self.timestamp_begin`, and timestamp_begin (50364) sits *above* every special marker, not below. It removes timestamps and nothing else, so the markers arrive as literal text and a denylist has to name each one.

Filtering by id instead. eot is the lowest special in both vocabularies -- 50257 multilingual, 50256 English-only -- so everything below it is transcript and everything at or above it is a marker, timestamps included. No list to keep in sync with the vocabulary.

_decode_tokens is a staticmethod taking the tokenizer now: all four call sites already had one in scope, so this also drops a _get_tokenizer() per streamed chunk, and lets the behaviour be tested against the real tokenizers with no GPU and no model.

tests/test_decode_tokens.py covers both vocabularies. Ran them against the denylist implementation first: 6 of the 12 fail there -- the prompt sequence, the full marker set, and <|nospeech|> -- and the 6 that pass either way are plain text and timestamps, which whisper's own filter already handled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transcript decoding by reliably removing prompt, timestamp, silence, and other special tokens.
  * Prevented special-token marker text from appearing in decoded transcripts.
  * Ensured empty token sequences produce empty transcripts.

* **Tests**
  * Added coverage for multilingual and English-only transcription decoding scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->