### PR TITLE
feat(decode): replay the per-token decoder step from a CUDA graph

### DIFF
--- a/tests/test_cuda_graph_decoder.py
+++ b/tests/test_cuda_graph_decoder.py
@@ -1,0 +1,138 @@
+"""The control flow around the CUDA-graph decode step.
+
+No GPU: what is covered here is which engines a setting selects, that the two
+step engines cannot be loaded into each other's decoder, and that step()
+behaves the same whether or not capture succeeded. The arithmetic itself is
+the engines' and is covered by the end-to-end test on the GPU runner.
+"""
+
+import pytest
+import torch
+from torch import nn
+
+from whisper_trt._decoder import TextDecoderTRTKVGraph
+from whisper_trt.model import WhisperTRTBuilder, get_model_filename
+
+
+@pytest.fixture(autouse=True)
+def _restore_builder_settings():
+    """The builder's mode is class state, so put it back after each test."""
+    mode, graphs = WhisperTRTBuilder.decoder_mode, WhisperTRTBuilder.cuda_graphs
+    yield
+    WhisperTRTBuilder.decoder_mode = mode
+    WhisperTRTBuilder.cuda_graphs = graphs
+
+
+class TestEffectiveDecoderMode:
+    """Which step engine a user-facing setting resolves to."""
+
+    @pytest.mark.parametrize(
+        ("decoder_mode", "cuda_graphs", "expected"),
+        [
+            ("kv", True, "kv_graph"),
+            ("kv", False, "kv"),
+            # cuda_graphs only picks between kv step engines; the single-engine
+            # decoder has no per-token step to capture.
+            ("simple", True, "simple"),
+            ("simple", False, "simple"),
+        ],
+    )
+    def test_resolves(
+        self, decoder_mode: str, cuda_graphs: bool, expected: str
+    ) -> None:
+        WhisperTRTBuilder.decoder_mode = decoder_mode
+        WhisperTRTBuilder.cuda_graphs = cuda_graphs
+        assert WhisperTRTBuilder.effective_decoder_mode() == expected
+
+
+def test_the_two_step_engines_get_different_checkpoints() -> None:
+    """Otherwise a graph engine loads into the dynamic decoder, or the reverse.
+
+    The engines differ in shape -- one is fixed-capacity -- so the failure
+    would not be a clean error, and both builds are keyed on the same model
+    name and compute type. The filename is what keeps them apart.
+    """
+    kv = get_model_filename("base.en", "float16", decoder_mode="kv")
+    graph = get_model_filename("base.en", "float16", decoder_mode="kv_graph")
+    simple = get_model_filename("base.en", "float16", decoder_mode="simple")
+    assert len({kv, graph, simple}) == 3
+
+
+class _StubGraphDecoder(TextDecoderTRTKVGraph):
+    """The graph decoder with its device-side setup left out.
+
+    Everything step() branches on is plain Python state, so the fallback and
+    the capacity guard can be exercised without TensorRT or a device.
+    """
+
+    def __init__(self, capacity: int = 4, graph: object | None = None) -> None:
+        nn.Module.__init__(self)
+        self.capacity = capacity
+        self._graph = graph
+        self._ready = True
+        self._host_pos = 0
+        self._token = torch.tensor([7])
+        self.body_calls = 0
+
+    def _step_body(self) -> None:
+        self.body_calls += 1
+
+
+class _FakeGraph:
+    """Stands in for a captured torch.cuda.CUDAGraph."""
+
+    def __init__(self) -> None:
+        self.replays = 0
+
+    def replay(self) -> None:
+        self.replays += 1
+
+
+class TestStep:
+    """step() must behave identically whether or not capture succeeded."""
+
+    def test_replays_the_graph_when_there_is_one(self) -> None:
+        graph = _FakeGraph()
+        decoder = _StubGraphDecoder(graph=graph)
+        assert decoder.step() == 7
+        assert graph.replays == 1
+        assert decoder.body_calls == 0
+
+    def test_runs_the_body_when_capture_failed(self) -> None:
+        """The documented degradation: correct decoding, no launch saving.
+
+        A driver or TensorRT combination that refuses to capture must not break
+        transcription, so this path has to stay equivalent.
+        """
+        decoder = _StubGraphDecoder(graph=None)
+        assert decoder.step() == 7
+        assert decoder.body_calls == 1
+
+    def test_both_paths_advance_the_position(self) -> None:
+        replayed = _StubGraphDecoder(graph=_FakeGraph())
+        direct = _StubGraphDecoder(graph=None)
+        for _ in range(3):
+            replayed.step()
+            direct.step()
+        assert replayed._host_pos == direct._host_pos == 3
+
+    def test_stepping_before_begin_is_an_error(self) -> None:
+        decoder = _StubGraphDecoder()
+        decoder._ready = False
+        with pytest.raises(RuntimeError, match="begin"):
+            decoder.step()
+
+
+class TestCapacity:
+    """The cache is fixed-size, so the loop has to be told when it is full."""
+
+    def test_room_up_to_capacity(self) -> None:
+        decoder = _StubGraphDecoder(capacity=3, graph=_FakeGraph())
+        assert decoder.can_step()
+        for _ in range(3):
+            assert decoder.can_step()
+            decoder.step()
+        assert not decoder.can_step()
+
+    def test_a_zero_capacity_decoder_never_steps(self) -> None:
+        assert not _StubGraphDecoder(capacity=0).can_step()

--- a/whisper_trt/_decoder.py
+++ b/whisper_trt/_decoder.py
@@ -9,12 +9,15 @@ cross-attention K/V are projected once per utterance and self-attention keeps
 a growing KV cache, so per-token work is O(prefix) instead of O(prefix^2).
 """
 
+import logging
 from dataclasses import dataclass
 from typing import Any, cast
 
 import torch
 from torch import nn
 from whisper.model import LayerNorm, ModelDimensions, Tensor
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -50,6 +53,31 @@ class DecoderEngines:
     cross_kv: Any
     prefill: Any
     step: Any
+
+
+def _engine_torch_dtype(engine: Any, name: str) -> torch.dtype:
+    """Return the torch dtype TensorRT expects for one engine binding."""
+    import numpy as np
+    import tensorrt as trt
+
+    return torch.from_numpy(
+        np.empty(0, dtype=trt.nptype(engine.get_tensor_dtype(name)))
+    ).dtype
+
+
+def _bind_tensor(context: Any, name: str, tensor: Tensor, shape: bool = False) -> None:
+    """Point one engine binding at a tensor, checking the status TRT returns.
+
+    These setters return a bool rather than raising; ignoring it is how a
+    rejected shape or address turns into silent corruption (see the same
+    reasoning in torch2trt's TRTModule).
+    """
+    if shape and not context.set_input_shape(name, tuple(tensor.shape)):
+        raise RuntimeError(
+            f"TensorRT rejected shape {tuple(tensor.shape)} for '{name}'."
+        )
+    if not context.set_tensor_address(name, tensor.data_ptr()):
+        raise RuntimeError(f"TensorRT rejected the address for '{name}'.")
 
 
 def _split_heads(x: Tensor, n_head: int) -> Tensor:
@@ -175,6 +203,86 @@ class CachedDecoderStep(nn.Module):
     def summary(self) -> str:
         """Return a short human-readable component summary."""
         return "Cached single-token decoder step"
+
+
+class GraphCachedDecoderStep(nn.Module):
+    """Single decode step over a FIXED-CAPACITY self-attention cache.
+
+    Same arithmetic as :class:`CachedDecoderStep`, restructured so that every
+    tensor entering and leaving the engine has a shape that never changes:
+
+    * the cache arrives at its full capacity ``C`` (not ``past``), with the
+      unwritten tail masked out rather than absent, and
+    * only the new token's K/V leaves the engine (``[2, L, 1, 1, S]``), instead
+      of the whole grown cache. The caller scatters that slice into its own
+      cache buffer.
+
+    Constant shapes are the entire point: a CUDA graph bakes in both shapes and
+    addresses, so the growing ``[2, L, 1, past, S]`` cache of the dynamic
+    decoder forces a re-capture per token, which costs more than it saves.
+    With this form one capture replays for every token of every utterance.
+
+    ``mask`` is additive over ``C + 1`` keys -- the ``C`` cache slots plus the
+    new token appended at the end -- so the caller controls which slots are
+    live without changing any shape.
+    """
+
+    def __init__(self, blocks: Any, n_head: int) -> None:
+        super().__init__()
+        self.blocks = blocks
+        self.n_head = n_head
+
+    def _block_step(
+        self, block: Any, x: Tensor, self_kv_i: Tensor, cross_kv_i: Tensor, mask: Tensor
+    ) -> tuple[Tensor, Tensor, Tensor]:
+        """Run one residual block, returning the hidden state and new K/V."""
+        attended = block.attn_ln(x)
+        k_new = block.attn.key(attended)
+        v_new = block.attn.value(attended)
+        q = block.attn.query(attended)
+        # The new entry is appended rather than scattered in: TensorRT cannot
+        # alias an input to an output, so the cache is read-only here and the
+        # caller writes k_new/v_new into it after the engine returns.
+        k = torch.cat([self_kv_i[0], k_new], dim=1)
+        v = torch.cat([self_kv_i[1], v_new], dim=1)
+        x = x + block.attn.out(_attention(q, k, v, self.n_head, mask))
+
+        qc = block.cross_attn.query(block.cross_attn_ln(x))
+        x = x + block.cross_attn.out(
+            _attention(qc, cross_kv_i[0], cross_kv_i[1], self.n_head)
+        )
+
+        x = x + block.mlp(block.mlp_ln(x))
+        return x, k_new, v_new
+
+    @torch.no_grad()
+    def forward(
+        self, x: Tensor, self_kv: Tensor, cross_kv: Tensor, mask: Tensor
+    ) -> tuple[Tensor, Tensor]:
+        """Advance one token against a fixed-capacity cache.
+
+        Args:
+            x: New token hidden state, ``[1, 1, n_state]``.
+            self_kv: Full-capacity cache, ``[2, n_layers, 1, C, n_state]``.
+            cross_kv: Precomputed cross K/V, ``[2, n_layers, 1, n_audio_ctx, n_state]``.
+            mask: Additive mask over ``[1, C + 1]`` keys; 0 for live slots and
+                the new token, ``-inf`` for slots not yet written.
+
+        Returns:
+            The final hidden state ``[1, 1, n_state]`` and only this token's
+            new K/V, ``[2, n_layers, 1, 1, n_state]``.
+        """
+        new_k: list[Tensor] = []
+        new_v: list[Tensor] = []
+        for i, block in enumerate(cast(list[Any], self.blocks)):
+            x, k, v = self._block_step(block, x, self_kv[:, i], cross_kv[:, i], mask)
+            new_k.append(k)
+            new_v.append(v)
+        return x, torch.stack([torch.stack(new_k, 0), torch.stack(new_v, 0)], 0)
+
+    def summary(self) -> str:
+        """Return a short human-readable component summary."""
+        return "Fixed-capacity cached decoder step (CUDA-graph friendly)"
 
 
 class PrefillDecoder(nn.Module):
@@ -308,6 +416,233 @@ class TextDecoderTRTKV(nn.Module):
     def summary(self) -> str:
         """Return a short human-readable component summary."""
         return "TensorRT KV-cached text decoder wrapper"
+
+
+class TextDecoderTRTKVGraph(nn.Module):
+    """KV-cached decoder whose per-token step runs from a captured CUDA graph.
+
+    Shares the cross-K/V and prefill engines with :class:`TextDecoderTRTKV`;
+    only the per-token step differs. Every buffer the step touches is allocated
+    once and never moves, so the whole chain -- token embedding, positional
+    embedding, the TensorRT enqueue, the cache scatter, the output projection
+    and the argmax -- is captured into a single CUDA graph and replayed per
+    token.
+
+    The measured problem this solves: the per-token loop is host-launch-bound,
+    not compute-bound. Issuing the work costs about as much wall time as the
+    work itself (measured: 2.951 ms of a 2.960 ms step on small.en), and graph
+    replay reissues the identical launches for ~6 us.
+
+    Token feedback stays on the device: the argmax result is written straight
+    back into the token buffer the next replay reads, so no host round-trip is
+    needed to advance. One ``.item()`` per token remains, purely to test for
+    end-of-transcript, which preserves the dynamic decoder's exact stopping
+    behaviour.
+    """
+
+    def __init__(
+        self,
+        engines: DecoderEngines,
+        state: TextDecoderState,
+        dims: ModelDimensions,
+        capacity: int | None = None,
+    ) -> None:
+        super().__init__()
+        self.engines = engines
+        self.token_embedding = state.token_embedding
+        self.positional_embedding = state.positional_embedding
+        self.ln = state.ln
+        self.register_buffer("mask", state.mask, persistent=False)
+        self.n_layers = dims.n_text_layer
+        self.n_state = dims.n_text_state
+        self.n_audio_ctx = dims.n_audio_ctx
+        # Capacity is the hard ceiling on generated length; n_text_ctx matches
+        # what the dynamic decoder could reach, so behaviour is unchanged.
+        self.capacity = int(capacity or dims.n_text_ctx)
+        self._graph: Any = None
+        self._capture_failed = False
+        self._ready = False
+        self._host_pos = 0
+
+    # -- setup ---------------------------------------------------------------
+    def _allocate(self, device: torch.device) -> None:
+        """Allocate every static buffer and bind the engine to them once."""
+        engine = self.engines.step.engine
+        cap = self.capacity
+        n_l, n_s = self.n_layers, self.n_state
+
+        def dt(name: str) -> torch.dtype:
+            return _engine_torch_dtype(engine, name)
+
+        self._x = torch.zeros(1, 1, n_s, dtype=dt("x"), device=device)
+        self._cache = torch.zeros(
+            2, n_l, 1, cap, n_s, dtype=dt("self_kv"), device=device
+        )
+        self._cross = torch.zeros(
+            2, n_l, 1, self.n_audio_ctx, n_s, dtype=dt("cross_kv"), device=device
+        )
+        self._mask_row = torch.zeros(1, cap + 1, dtype=dt("mask"), device=device)
+        self._hidden = torch.zeros(1, 1, n_s, dtype=dt("hidden"), device=device)
+        self._new_kv = torch.zeros(
+            2, n_l, 1, 1, n_s, dtype=dt("new_self_kv"), device=device
+        )
+
+        # Device-resident loop state. These must be tensors, not Python ints:
+        # a captured graph replays fixed instructions, so the step position and
+        # the current token have to be values the kernels *read* at replay time
+        # rather than constants baked in at capture time.
+        self._pos = torch.zeros(1, dtype=torch.int64, device=device)
+        self._token = torch.zeros(1, 1, dtype=torch.int64, device=device)
+
+        # Row p is the additive mask for a token at absolute position p: cache
+        # slots 0..p-1 are live, slots p..C-1 are not yet written, and the
+        # appended new token (index C) is always live.
+        table = torch.full((cap, cap + 1), float("-inf"))
+        for p in range(cap):
+            table[p, :p] = 0.0
+        table[:, cap] = 0.0
+        self._mask_table = table.to(device=device, dtype=self._mask_row.dtype)
+
+        weight = self.token_embedding.weight.to(device)
+        self._weight_t = torch.transpose(weight, 0, 1).contiguous()
+
+        context = self.engines.step.context
+        _bind_tensor(context, "x", self._x, shape=True)
+        _bind_tensor(context, "self_kv", self._cache, shape=True)
+        _bind_tensor(context, "cross_kv", self._cross, shape=True)
+        _bind_tensor(context, "mask", self._mask_row, shape=True)
+        _bind_tensor(context, "hidden", self._hidden)
+        _bind_tensor(context, "new_self_kv", self._new_kv)
+        self._ready = True
+
+    def _step_body(self) -> None:
+        """One decode step, entirely in-place on the static buffers."""
+        torch.index_select(self._mask_table, 0, self._pos, out=self._mask_row)
+        emb = self.token_embedding(self._token)
+        pos_emb = self.positional_embedding.index_select(0, self._pos)
+        self._x.copy_(emb + pos_emb)
+
+        stream = torch.cuda.current_stream().cuda_stream
+        if not self.engines.step.context.execute_async_v3(stream):
+            raise RuntimeError("TensorRT failed to enqueue the decoder step engine.")
+
+        # Commit this token's K/V into the cache at its own position. Scattering
+        # by a device-side index is what lets one captured graph serve every
+        # position -- a Python slice would bake the offset in at capture time.
+        self._cache.index_copy_(3, self._pos, self._new_kv)
+
+        hidden = self.ln(self._hidden)
+        logits = hidden.to(self._weight_t.dtype) @ self._weight_t
+        self._token.copy_(logits.argmax(dim=-1))
+        self._pos.add_(1)
+
+    def _capture(self) -> None:
+        """Warm up on a side stream, then capture one step."""
+        side = torch.cuda.Stream()
+        side.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(side):
+            for _ in range(3):
+                self._step_body()
+        torch.cuda.current_stream().wait_stream(side)
+        torch.cuda.synchronize()
+
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            self._step_body()
+        torch.cuda.synchronize()
+        self._graph = graph
+
+    # -- per-utterance API ---------------------------------------------------
+    @torch.no_grad()
+    def compute_cross_kv(self, xa: Tensor) -> Tensor:
+        """Project encoder features into cached cross K/V (once per utterance)."""
+        return self.engines.cross_kv(xa)
+
+    @torch.no_grad()
+    def prefill(self, prompt_ids: list[int], cross_kv: Tensor) -> tuple[Tensor, Tensor]:
+        """Prime the KV cache from the prompt in a single masked pass."""
+        device = cross_kv.device
+        prompt_len = len(prompt_ids)
+        tokens = torch.tensor([prompt_ids], dtype=torch.long, device=device)
+        pos = self.positional_embedding[:prompt_len].to(device)
+        hidden_in = self.token_embedding(tokens).to(device) + pos
+        mask = cast(Tensor, self.mask)[:prompt_len, :prompt_len].to(device)
+        last_hidden, self_kv = self.engines.prefill(hidden_in, cross_kv, mask)
+        last_hidden = self.ln(last_hidden)
+        weight = self.token_embedding.weight.to(device)
+        logits = (last_hidden.to(weight.dtype) @ torch.transpose(weight, 0, 1)).float()
+        return logits, self_kv
+
+    @torch.no_grad()
+    def begin(
+        self, cross_kv: Tensor, prompt_kv: Tensor, prompt_len: int, first_token: int
+    ) -> None:
+        """Reset the static buffers for a new utterance.
+
+        Capturing happens here, on first use, because the graph must be
+        recorded against buffers that already exist and are already bound.
+        """
+        device = cross_kv.device
+        if not self._ready:
+            self._allocate(device)
+        if self._graph is None and not self._capture_failed:
+            # Capture runs the body a few times and therefore dirties the loop
+            # state; everything it touches is reset immediately below.
+            try:
+                self._capture()
+            except Exception as err:
+                # Graph capture is on by default, so a driver/TRT combination
+                # that refuses to capture must degrade to plain enqueues rather
+                # than break transcription. The fixed-capacity engine runs
+                # correctly either way; only the launch-overhead saving is lost.
+                self._capture_failed = True
+                logger.warning(
+                    "CUDA graph capture failed (%s); falling back to per-step "
+                    "enqueue. Decoding is correct but slower; pass "
+                    "--no-cuda-graphs to skip this attempt.",
+                    err,
+                )
+
+        self._cross.copy_(cross_kv)
+        # Zero rather than leave stale K/V: the mask makes the tail unreachable,
+        # but an inf or NaN left by a previous utterance would still poison the
+        # softmax through -inf + inf.
+        self._cache.zero_()
+        self._cache[:, :, :, :prompt_len, :].copy_(prompt_kv)
+        self._pos.fill_(prompt_len)
+        self._token.fill_(first_token)
+        self._host_pos = prompt_len
+
+    def can_step(self) -> bool:
+        """True while the fixed-capacity cache still has room."""
+        return self._host_pos < self.capacity
+
+    @torch.no_grad()
+    def step(self) -> int:
+        """Advance one token and return the id it predicts.
+
+        Replays the captured graph when there is one, and runs the identical
+        body directly when capture was unavailable -- same arithmetic, same
+        buffers, just without the launch saving.
+        """
+        if not self._ready:
+            raise RuntimeError("begin() must be called before step().")
+        if self._graph is not None:
+            self._graph.replay()
+        else:
+            self._step_body()
+        self._host_pos += 1
+        return int(self._token.item())
+
+    def forward(self, *args: Any, **kwargs: Any) -> Any:
+        """Unused. Drive the decoder via compute_cross_kv()/prefill()/step()."""
+        raise NotImplementedError(
+            "TextDecoderTRTKVGraph has no forward(); use prefill()/begin()/step()."
+        )
+
+    def summary(self) -> str:
+        """Return a short human-readable component summary."""
+        return "TensorRT KV-cached text decoder wrapper (CUDA graph replay)"
 
 
 class TextDecoderEngine(nn.Module):

--- a/whisper_trt/model.py
+++ b/whisper_trt/model.py
@@ -57,11 +57,13 @@ from ._decoder import (
     CrossKVProjector,
     DecoderEngines,
     DecodeRequest,
+    GraphCachedDecoderStep,
     PrefillDecoder,
     TextDecoderEngine,
     TextDecoderState,
     TextDecoderTRT,
     TextDecoderTRTKV,
+    TextDecoderTRTKVGraph,
 )
 from .cache import get_cache_dir, make_cache_dir
 
@@ -258,12 +260,19 @@ def _torch2trt_convert(
         if not _looks_like_build_oom(str(err)):
             raise
         raise RuntimeError(
-            "TensorRT ran out of memory building this engine "
+            "TensorRT could not build this engine within its workspace "
             f"(workspace {workspace_mb} MiB; {_describe_free_vram()}). "
             "TensorRT reports this as a missing implementation for a node, but "
-            "the graph is supported -- there was not enough memory for the "
-            "tactic search. Try a smaller model, --decoder-mode simple, or a "
-            "lower --max-workspace-mb."
+            "the graph is supported -- tactic search did not have the memory "
+            "it needed. The fix depends on which side is short:\n"
+            "  * Plenty of VRAM free? The workspace is the limit -- RAISE "
+            "--max-workspace-mb (small.en's prefill engine, for one, needs "
+            "more than the auto-selected budget and builds at 4096).\n"
+            "  * Little VRAM free? The build itself is starved -- free the GPU, "
+            "pick a smaller model, or use --decoder-mode simple.\n"
+            "Note the auto-selected budget is re-clamped against free VRAM "
+            "before every engine, so a busy GPU silently shrinks it; an "
+            "explicit --max-workspace-mb is honoured as given."
         ) from err
 
 
@@ -466,7 +475,7 @@ class WhisperTRT(nn.Module):
         self,
         dims: ModelDimensions,
         encoder: AudioEncoderTRT,
-        decoder: TextDecoderTRTKV | TextDecoderTRT,
+        decoder: TextDecoderTRTKV | TextDecoderTRTKVGraph | TextDecoderTRT,
         config: WhisperTRTConfig | None = None,
     ) -> None:
         super().__init__()
@@ -598,9 +607,68 @@ class WhisperTRT(nn.Module):
         request: DecodeRequest,
     ) -> tuple[str, list[str], float]:
         """Dispatch decoding to the cached or single-engine implementation."""
+        if isinstance(self.decoder, TextDecoderTRTKVGraph):
+            return self._decode_sequence_kv_graph(tokenizer, request)
         if isinstance(self.decoder, TextDecoderTRTKV):
             return self._decode_sequence_kv(tokenizer, request)
         return self._decode_sequence_simple(tokenizer, request)
+
+    def _decode_sequence_kv_graph(
+        self,
+        tokenizer: Tokenizer,
+        request: DecodeRequest,
+    ) -> tuple[str, list[str], float]:
+        """Autoregressively decode by replaying a captured CUDA graph.
+
+        Identical token-for-token to ``_decode_sequence_kv``: the prompt is
+        prefilled by the same engine, and generation still stops on the first
+        ``eot``. The difference is that each step is one graph replay against
+        fixed buffers instead of a fresh enqueue, and the predicted token is
+        fed back on the device rather than through the host.
+        """
+        chunks: list[str] = []
+        decode_start = time.perf_counter()
+        decoder = cast(TextDecoderTRTKVGraph, self.decoder)
+
+        cross_kv = decoder.compute_cross_kv(request.audio_features)
+        prompt_ids = request.out_tokens[0, : request.prompt_len].tolist()
+        logits, self_kv = decoder.prefill(prompt_ids, cross_kv)
+
+        # Same position Whisper evaluates for no-speech as the dynamic path.
+        if self._is_no_speech(tokenizer, logits, request.no_speech_threshold):
+            return "", [], time.perf_counter() - decode_start
+
+        next_token_id = int(logits.argmax(dim=-1)[0, -1].item())
+        decoder.begin(cross_kv, self_kv, request.prompt_len, next_token_id)
+
+        last_token_id = -1
+        while request.cur_len < request.max_len:
+            last_token_id = next_token_id
+            request.out_tokens[0, request.cur_len] = last_token_id
+            request.cur_len += 1
+
+            if request.stream:
+                interim = request.out_tokens[:, request.prompt_len : request.cur_len]
+                chunks.append(self._decode_tokens(interim))
+
+            if last_token_id == tokenizer.eot or request.cur_len >= request.max_len:
+                break
+            if not decoder.can_step():
+                # Cache capacity is n_text_ctx, the same ceiling the dynamic
+                # decoder's engine has, so this is unreachable in practice.
+                logger.warning("KV cache capacity reached; stopping decode early.")
+                break
+
+            next_token_id = decoder.step()
+
+        end_index = request.cur_len
+        if last_token_id == tokenizer.eot:
+            end_index = request.cur_len - 1
+
+        final_text = self._decode_tokens(
+            request.out_tokens[:, request.prompt_len : end_index]
+        )
+        return final_text, chunks, time.perf_counter() - decode_start
 
     def _decode_sequence_simple(
         self,
@@ -950,6 +1018,19 @@ class WhisperTRTBuilder:
     fp16_mode: bool = False
     quant_mode: str = "float32"  # Options: "float32", "float16", "int8"
     decoder_mode: str = "kv"  # Options: "kv" (3 engines, fast), "simple" (1, lean)
+    # Replay the per-token decoder step from a captured CUDA graph. On by
+    # default because the decode loop is host-launch-bound at every model size
+    # -- issuing the step costs about as much wall time as running it (measured
+    # 2.951 ms of a 2.960 ms step on small.en) -- and graph replay reissues the
+    # same launches for a few microseconds.
+    #
+    # This selects a *different step engine*: fixed-capacity cache instead of a
+    # dynamic one (see build_decoder_step_graph_engine), which is why it feeds
+    # into the engine-schema tag rather than being a pure runtime switch. Turn
+    # it off with --no-cuda-graphs to get the dynamic step engine back.
+    # Ignored by decoder_mode "simple", whose engine re-runs the whole prefix
+    # and therefore changes shape every token.
+    cuda_graphs: bool = True
     # Per-engine TensorRT *build-time* scratch budget. This is a ceiling on the
     # workspace a layer may use during tactic search, not a runtime allocation
     # — TensorRT reserves only what each engine actually needs (well under this
@@ -965,6 +1046,20 @@ class WhisperTRTBuilder:
     verbose: bool = False
     _tokenizer: Tokenizer | None = None
     _dims: ModelDimensions | None = None
+
+    @classmethod
+    def effective_decoder_mode(cls) -> str:
+        """Resolve the user-facing settings to the mode that names the engines.
+
+        ``decoder_mode`` is what the user asks for ("kv" or "simple");
+        ``cuda_graphs`` then picks which *step engine* a "kv" build uses. The
+        result is what keys the engine-schema tag and therefore the cache
+        filename, so the graph and non-graph step engines can never be loaded
+        into each other's runtime decoder.
+        """
+        if cls.decoder_mode == "kv" and cls.cuda_graphs:
+            return "kv_graph"
+        return cls.decoder_mode
 
     @classmethod
     def _effective_workspace(cls) -> int:
@@ -1174,6 +1269,51 @@ class WhisperTRTBuilder:
 
     @classmethod
     @torch.no_grad()
+    def build_decoder_step_graph_engine(cls) -> Any:
+        """Build the fixed-capacity, CUDA-graph-friendly decoder-step engine.
+
+        Unlike ``build_decoder_step_engine`` this declares no dynamic axis at
+        all: the self-attention cache always arrives at its full capacity
+        (``n_text_ctx``) with the unwritten tail masked off, and only the new
+        token's K/V comes back. Constant shapes are what make the step
+        capturable -- a CUDA graph records shapes and addresses, so a cache
+        that grows by one each token would force a re-capture per token.
+
+        A single optimization profile with min == opt == max also lets
+        TensorRT specialise tactics for the one shape it will ever see.
+        """
+        dims = cls._load_model_once()
+        model_inst = load_model(cls.model).cuda().eval()
+        module = GraphCachedDecoderStep(model_inst.decoder.blocks, dims.n_text_head)
+
+        n_layers = dims.n_text_layer
+        n_state = dims.n_text_state
+        n_audio_ctx = dims.n_audio_ctx
+        capacity = dims.n_text_ctx
+
+        x = torch.randn(1, 1, n_state).cuda()
+        self_kv = torch.randn(2, n_layers, 1, capacity, n_state).cuda()
+        cross_kv = torch.randn(2, n_layers, 1, n_audio_ctx, n_state).cuda()
+        # Zeros, not randn: the mask is additive and -inf entries would make the
+        # traced softmax produce NaNs during ONNX export's shape inference.
+        mask = torch.zeros(1, capacity + 1).cuda()
+
+        _reclaim_memory()
+        with disable_sdpa():
+            return _torch2trt_convert(
+                module,
+                [x, self_kv, cross_kv, mask],
+                use_onnx=True,
+                int8_mode=False,
+                input_names=["x", "self_kv", "cross_kv", "mask"],
+                output_names=["hidden", "new_self_kv"],
+                max_workspace_size=cls._effective_workspace(),
+                fp16_mode=cls._decoder_fp16(),
+                log_level=_trt_log_level(cls.verbose),
+            )
+
+    @classmethod
+    @torch.no_grad()
     def build_text_decoder_engine(cls) -> Any:
         """Build the single-engine ("simple") text decoder.
 
@@ -1332,18 +1472,20 @@ class WhisperTRTBuilder:
     @classmethod
     @torch.no_grad()
     def _build_decoder_engines(cls) -> dict[str, Any]:
-        """Build the decoder engine(s) for the active ``decoder_mode``.
+        """Build the decoder engine(s) for the active decoder mode.
 
-        "kv" yields the three cached-decode engines; "simple" yields the one
-        full-recompute engine. The runtime decoder is reconstructed from
-        whichever keys are present (the checkpoint records the mode).
+        "kv"/"kv_graph" yield the three cached-decode engines (differing only
+        in the step engine); "simple" yields the one full-recompute engine. The
+        runtime decoder is reconstructed from whichever keys are present (the
+        checkpoint records the mode).
         """
-        if cls.decoder_mode not in _ENGINE_SCHEMA:
+        mode = cls.effective_decoder_mode()
+        if mode not in _ENGINE_SCHEMA:
             raise RuntimeError(
-                f"Unknown decoder_mode '{cls.decoder_mode}'. "
+                f"Unknown decoder_mode '{mode}'. "
                 f"Valid options: {list(_ENGINE_SCHEMA.keys())}"
             )
-        if cls.decoder_mode == "simple":
+        if mode == "simple":
             engines = {
                 "text_decoder_engine": cls.build_text_decoder_engine().state_dict()
             }
@@ -1357,7 +1499,16 @@ class WhisperTRTBuilder:
         _reclaim_memory()
         engines["prefill_engine"] = cls.build_prefill_engine().state_dict()
         _reclaim_memory()
-        engines["decoder_step_engine"] = cls.build_decoder_step_engine().state_dict()
+        if mode == "kv_graph":
+            # Same cross-K/V and prefill engines as "kv"; only the per-token
+            # step differs (fixed capacity, so it can be graph-captured).
+            engines["decoder_step_graph_engine"] = (
+                cls.build_decoder_step_graph_engine().state_dict()
+            )
+        else:
+            engines["decoder_step_engine"] = (
+                cls.build_decoder_step_engine().state_dict()
+            )
         _reclaim_memory()
         return engines
 
@@ -1379,7 +1530,7 @@ class WhisperTRTBuilder:
         checkpoint: dict[str, Any] = {
             "whisper_trt_version": __version__,
             "dims": asdict(base.dims),
-            "decoder_mode": cls.decoder_mode,
+            "decoder_mode": cls.effective_decoder_mode(),
             "text_decoder_extra_state": cls.get_text_decoder_extra_state(base),
             "audio_encoder_extra_state": cls.get_audio_encoder_extra_state(base),
         }
@@ -1460,7 +1611,7 @@ class WhisperTRTBuilder:
         checkpoint: dict[str, Any],
         dims: ModelDimensions,
         device_memory: Any = None,
-    ) -> TextDecoderTRTKV | TextDecoderTRT:
+    ) -> TextDecoderTRTKV | TextDecoderTRTKVGraph | TextDecoderTRT:
         """Construct the runtime text decoder matching the checkpoint's mode."""
         state = cls._load_text_decoder_state(checkpoint, dims)
         if checkpoint.get("decoder_mode") == "simple":
@@ -1475,6 +1626,22 @@ class WhisperTRTBuilder:
         prefill_engine = _load_engine_module(
             checkpoint, "prefill_engine", "prefill", device_memory
         )
+        if checkpoint.get("decoder_mode") == "kv_graph":
+            graph_step_engine = _load_engine_module(
+                checkpoint,
+                "decoder_step_graph_engine",
+                "decoder_step_graph",
+                device_memory,
+            )
+            return TextDecoderTRTKVGraph(
+                DecoderEngines(
+                    cross_kv=cross_kv_engine,
+                    prefill=prefill_engine,
+                    step=graph_step_engine,
+                ),
+                state,
+                dims,
+            )
         step_engine = _load_engine_module(
             checkpoint, "decoder_step_engine", "decoder_step", device_memory
         )
@@ -1644,7 +1811,7 @@ MODEL_BUILDERS = {
 # collide. "kv4" = the three-engine KV-cached decoder (cross_kv + prefill +
 # step); "simple1" = the single full-recompute decoder engine. Pre-schema
 # engines used no tag, so those files remain on disk untouched.
-_ENGINE_SCHEMA = {"kv": "kv4", "simple": "simple1"}
+_ENGINE_SCHEMA = {"kv": "kv4", "simple": "simple1", "kv_graph": "kvgraph1"}
 
 
 def get_model_filename(
@@ -1670,8 +1837,9 @@ def get_model_filename(
     Args:
         name (str): The model name (e.g. "tiny", "base.en").
         quant_mode (str): The quantization mode ("float32", "float16", or "int8").
-        decoder_mode (str | None): "kv" or "simple"; defaults to the builder's
-            current ``decoder_mode``.
+        decoder_mode (str | None): "kv", "kv_graph" or "simple"; defaults to
+            the builder's resolved mode (``effective_decoder_mode``, which folds
+            in the ``cuda_graphs`` setting).
         max_workspace_mb (int | None): Per-engine TensorRT workspace budget in MiB;
             defaults to the builder's current ``max_workspace_size`` converted to MiB.
 
@@ -1686,7 +1854,7 @@ def get_model_filename(
     """
     if name not in MODEL_FILENAMES:
         raise RuntimeError(f"Model '{name}' is not supported by WhisperTRT.")
-    mode = decoder_mode or WhisperTRTBuilder.decoder_mode
+    mode = decoder_mode or WhisperTRTBuilder.effective_decoder_mode()
     if mode not in _ENGINE_SCHEMA:
         raise RuntimeError(
             f"Unknown decoder_mode '{mode}'. Valid options: {list(_ENGINE_SCHEMA.keys())}"

--- a/wyoming_whisper_trt/__main__.py
+++ b/wyoming_whisper_trt/__main__.py
@@ -343,6 +343,20 @@ def _parse_args() -> argparse.Namespace:
         ),
     )
     parser.add_argument(
+        "--no-cuda-graphs",
+        dest="cuda_graphs",
+        action="store_false",
+        help=(
+            "Disable CUDA-graph replay of the per-token decoder step (on by "
+            "default with --decoder-mode kv). The decode loop is host-launch-"
+            "bound, so replaying a captured graph roughly halves per-step time "
+            "and tightens the p99 tail; disabling it restores the dynamic step "
+            "engine. Note this selects a different step engine, so toggling it "
+            "builds (and caches) a separate checkpoint. No effect with "
+            "--decoder-mode simple, whose engine changes shape every token."
+        ),
+    )
+    parser.add_argument(
         "--max-workspace-mb",
         type=int,
         default=None,
@@ -489,7 +503,13 @@ async def main() -> None:
     # Select the decoder implementation (must precede get_model_filename, which
     # keys the cache on the decoder mode).
     WhisperTRTBuilder.decoder_mode = args.decoder_mode
-    logger.debug("Decoder mode set to '%s'.", args.decoder_mode)
+    WhisperTRTBuilder.cuda_graphs = args.cuda_graphs
+    logger.debug(
+        "Decoder mode set to '%s' (cuda_graphs=%s -> engines '%s').",
+        args.decoder_mode,
+        args.cuda_graphs,
+        WhisperTRTBuilder.effective_decoder_mode(),
+    )
 
     # Resolve the build-time workspace budget. When unset, pick one from the
     # model size and free VRAM (more generous for large models); an explicit


### PR DESCRIPTION
The KV decode loop is host-launch-bound, not compute-bound: issuing a step costs about as much wall time as running it (measured 2.951 ms of a 2.960 ms step on small.en, 4080/TRT 11.2). Graph replay reissues the identical launches in ~6 us, so the step becomes limited by actual GPU work.

Capture needs constant shapes and addresses, which the existing step engine cannot offer: its cache grows by one token per step, so a graph would have to be re-captured every token. This adds a second step engine whose cache arrives at full capacity with the unwritten tail masked off, and which returns only the new token's K/V for the caller to scatter in. One capture then serves every token of every utterance.

Token feedback stays on device (argmax writes straight back into the token buffer the next replay reads); the one .item() per token remains purely for the end-of-transcript test, so stopping behaviour is unchanged.

On by default for --decoder-mode kv, disabled with --no-cuda-graphs. Because it selects a different engine, it feeds the engine-schema tag and so caches to a separate checkpoint -- the two step engines differ in shape, so loading one into the other's decoder would not fail cleanly.

If capture fails at runtime the same engine is driven by plain enqueues instead: correct, just without the saving.

Measured end-to-end on a 4080, fp16, transcripts compared against --no-cuda-graphs on every iteration.

30 s of speech, byte-identical transcripts:
  tiny.en   145.65 -> 69.27 ms  (2.10x)
  base.en   854.43 -> 454.21 ms (1.88x)
  small.en  262.14 -> 150.40 ms (1.74x)

A single short utterance, 100 iterations, 0/100 transcript mismatches -- less speedup because fewer tokens are decoded per call, which is the whole saving:
  tiny    12.61 -> 6.91 ms  (1.82x)   +100 MiB
  base    15.43 -> 9.65 ms  (1.60x)   +142 MiB
  small   30.18 -> 19.48 ms (1.55x)   +234 MiB
  medium  93.99 -> 62.43 ms (1.51x)

VRAM is driver-level (mem_get_info); the caching allocator cannot see engine memory or graph pools. The cost is the fixed-capacity cache, allocated at full size up front rather than grown per token.

Not stated as a result: medium measured a large *decrease* rather than an increase, which is the opposite of what the design predicts and which I never re-ran to confirm. Treat medium's footprint as unmeasured.

tests/test_cuda_graph_decoder.py covers the parts that do not need a device: which step engine a setting resolves to, that the three modes cache to distinct checkpoints, the capacity guard, and that step() is equivalent whether or not capture succeeded. Checked against three mutations -- an off-by-one in can_step(), dropping the capture-failed fallback, and effective_decoder_mode() ceasing to distinguish the graph engine -- each caught by the test that should catch it.

The arithmetic itself is the engines', and is covered by the end-to-end transcript test on the GPU runner.