### PR TITLE
fix: pin the repository to LF so Windows checkouts can build the image

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,20 @@
+# Normalize line endings in the repository to LF.
+#
+# Without this, a checkout on Windows with core.autocrlf=true rewrites these
+# files with CRLF. That is harmless for the .py sources, but fatal for anything
+# executed as a script inside the Linux container: `docker build` copies the
+# working tree in, and script/setup then dies with
+#     /usr/bin/env: 'python3\r': No such file or directory
+# because the CR is parsed as part of the shebang's interpreter name.
+* text=auto eol=lf
+
+# Executables and shell scripts must be LF regardless of platform.
+script/* text eol=lf
+*.sh text eol=lf
+run.sh text eol=lf
+
+# Binary assets must never be line-ending converted.
+*.wav binary
+*.png binary
+*.jpg binary
+*.pdf binary


### PR DESCRIPTION
A checkout with core.autocrlf=true -- the Windows default -- rewrites the working tree with CRLF. Harmless for the .py sources, fatal for anything the Linux container executes as a script: `docker build` copies the working tree into the image, and script/setup then dies with

    /usr/bin/env: 'python3\r': No such file or directory

because the CR is parsed as part of the shebang's interpreter name.

Reproducible on any Windows checkout today. git stores the shebang as "python3\n"; the same file in a working tree with autocrlf=true reads "python3\r\n".

`git add --renormalize .` reports nothing to change, so every tracked file is already LF in the index -- this only stops checkouts from undoing that, and adds no churn. Existing Windows working copies need a re-checkout to pick up the new normalization.

Also marks the binary assets so they are never line-ending converted; the bundled .wav the tests transcribe is one of them.