### PR TITLE
ci(security): scope the release workflow's GITHUB_TOKEN to contents: …

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,5 +1,13 @@
 ---
 name: Release
+
+# Every write this workflow performs -- creating, publishing and closing the
+# release -- goes through PERSONAL_GITHUB_TOKEN. The default GITHUB_TOKEN is
+# only used implicitly, by actions/checkout, to clone. Without this block it
+# was issued with the repository's default (write) scopes for no reason.
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
…read

release.yaml had no permissions block, so its GITHUB_TOKEN was issued with the repository's default scopes -- write, on a workflow that runs on every push to release/*.

It needs none of them. Creating, publishing and closing the release all go through PERSONAL_GITHUB_TOKEN, as does the gh api call that waits for the draft to become visible; the default token is used only implicitly, by actions/checkout, to clone.

This was the last workflow without an explicit block -- the other five already scope theirs.