### PR TITLE
fix(ci): stop the GPU end-to-end tests OOMing the TensorRT build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -175,7 +175,14 @@ jobs:
           WHISPER_TRT_TEST_DATA_DIR: ${{ env.DATA_DIR }}
         run: |
           mkdir -p "$WHISPER_TRT_TEST_DATA_DIR"
-          .venv/bin/python -m pytest tests -v -ra
+          # Two invocations, not one. The end-to-end suite spawns servers that
+          # build TensorRT engines, and anything an earlier test left resident
+          # in this process is memory those builds cannot have -- test_quant
+          # constructs TRT builders, each of which holds a CUDA context for the
+          # rest of the session. Running it in its own process makes the
+          # engine builds see a GPU with only their own allocations on it.
+          .venv/bin/python -m pytest tests -v -ra --ignore=tests/test_wyoming_whisper_trt.py
+          .venv/bin/python -m pytest tests/test_wyoming_whisper_trt.py -v -ra
 
       # 5. Start the server exactly as the container does, and assert what it
       # actually loaded.

--- a/tests/test_wyoming_whisper_trt.py
+++ b/tests/test_wyoming_whisper_trt.py
@@ -39,6 +39,8 @@ _PROGRAM_DIR = _DIR.parent
 # cache mount: pointing this there pays the build once instead of every run.
 _LOCAL_DIR = Path(os.environ.get("WHISPER_TRT_TEST_DATA_DIR") or _PROGRAM_DIR / "local")
 _SAMPLES_PER_CHUNK = 1024
+# See the note where this is passed to the server.
+_TEST_WORKSPACE_MB = 512
 # Generous: covers a cold TensorRT engine build before the port opens.
 _STARTUP_TIMEOUT = 600
 _TRANSCRIBE_TIMEOUT = 120
@@ -206,6 +208,19 @@ async def test_wyoming_whisper_trt(compute_type: str, decoder_mode: str) -> None
         decoder_mode,
         "--language",
         "en",
+        # Pinned rather than auto-sized, for two reasons.
+        #
+        # auto_workspace_mb derives the budget from free VRAM *at that moment*,
+        # and get_model_filename keys the engine cache on the budget. So when
+        # VRAM is tight the chosen budget differs, the cached engine no longer
+        # matches by name, and the run is forced into exactly the rebuild that
+        # needs the memory it has not got. Pinning it makes the cache hit.
+        #
+        # And these tests prove transcription is correct, not that tactic
+        # search had a generous budget; 512 MiB builds the same engine with
+        # less search, and leaves that much more room for the build itself.
+        "--max-workspace-mb",
+        str(_TEST_WORKSPACE_MB),
         stdin=DEVNULL,
         stdout=PIPE,
         stderr=PIPE,


### PR DESCRIPTION
The three end-to-end tests each spawn a server that builds engines for `base`, and on the self-hosted runner all three now die during the build:

    Error Code 1: Cuda Runtime (cudaError 2: out of memory)
    autotuning: User allocator error allocating 11534336-byte buffer
    Could not find any implementation for node ...

An 11 MiB allocation failing means the GPU was essentially full, not that the build was too ambitious. Two things make that happen, and this fixes both.

The suite runs in one pytest process, and test_quant constructs TensorRT builders -- each holding a CUDA context for the rest of the session. By the time the end-to-end tests spawn their servers, that memory is gone from the GPU and unavailable to the builds. They run in their own invocation now, so a build sees a GPU carrying only its own allocations. Confirmed the split loses nothing: 78 + 7 passed and 1 + 3 skipped, against 85 and 4 for the combined run.

Second, and worse as a feedback loop: auto_workspace_mb derives the budget from free VRAM *at that moment*, and get_model_filename keys the engine cache on the budget. So when VRAM is tight the chosen budget differs from the cached engine's, the cache misses by name, and the run is forced into exactly the rebuild that needs the memory it has not got -- the cache stops working precisely when it is most needed. The tests pin --max-workspace-mb, which makes the cache hit and bounds the build.

512 MiB, not the 1024 a healthy GPU auto-selects for `base`: these tests prove transcription is correct, not that tactic search had a generous budget, and the smaller ceiling leaves that much more room for the build itself. It is still twice _MIN_WORKSPACE_MB, which is what the code already treats as workable.

Only the tests are pinned. The auto-sizing feedback loop is real for users too, but changing how the cache is keyed invalidates every existing engine on disk, so that is its own change.