### PR TITLE
Fix/unpin test workspace

### DIFF
--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -234,3 +234,52 @@ class TestUnsupportedArchWarningFilter:
             "compatible with the current PyTorch installation."
         )
         assert not self._filtered("some unrelated deprecation")
+
+
+class TestBudgetIsStableEnoughToCacheOn:
+    """The budget lands in the engine cache filename, so it must not drift.
+
+    ``get_model_filename`` keys the checkpoint on the workspace. An unrounded
+    budget tracks free VRAM continuously -- 3800 MiB free gave ws876, 3500 gave
+    ws726 -- so two runs of the same build on one machine disagreed about the
+    filename, the cache missed, and the run was pushed into the rebuild it was
+    short of memory for. The cache stopped working exactly when it mattered.
+    """
+
+    @pytest.mark.parametrize(
+        "free_mb", [2500, 2800, 3000, 3333, 3500, 3800, 4000, 4096, 5000, 7777]
+    )
+    def test_the_budget_is_always_a_whole_number_of_buckets(self, free_mb: int) -> None:
+        with _free_vram(free_mb):
+            assert auto_workspace_mb("base") % _MIN_WORKSPACE_MB == 0
+
+    @pytest.mark.parametrize(
+        ("low_mb", "high_mb"),
+        [
+            # Each pair straddles a few hundred MiB of drift -- another process
+            # taking memory, or a previous engine still resident -- without
+            # crossing a bucket. Unrounded, every one of these changed the name.
+            (3400, 3500),
+            (3600, 3700),
+            (3800, 3900),
+            (4200, 4800),
+        ],
+    )
+    def test_nearby_vram_gives_the_same_budget(self, low_mb: int, high_mb: int) -> None:
+        with _free_vram(low_mb):
+            low = auto_workspace_mb("base")
+        with _free_vram(high_mb):
+            high = auto_workspace_mb("base")
+        assert low == high
+
+    @pytest.mark.parametrize("free_mb", [3333, 3800, 5555])
+    def test_rounding_goes_down_never_up(self, free_mb: int) -> None:
+        """Rounding up would hand back more than the VRAM clamp allows."""
+        unrounded = int(_VRAM_FRACTION * (free_mb - _BUILD_MEMORY_RESERVE_MB))
+        with _free_vram(free_mb):
+            assert auto_workspace_mb("base") <= max(unrounded, _MIN_WORKSPACE_MB)
+
+    def test_the_floor_still_wins_when_there_is_nothing_spare(self) -> None:
+        """Rounding must not push a tight budget below the floor, or to zero."""
+        with _free_vram(_BUILD_MEMORY_RESERVE_MB):
+            assert auto_workspace_mb("base") == _MIN_WORKSPACE_MB

--- a/tests/test_wyoming_whisper_trt.py
+++ b/tests/test_wyoming_whisper_trt.py
@@ -39,8 +39,6 @@ _PROGRAM_DIR = _DIR.parent
 # cache mount: pointing this there pays the build once instead of every run.
 _LOCAL_DIR = Path(os.environ.get("WHISPER_TRT_TEST_DATA_DIR") or _PROGRAM_DIR / "local")
 _SAMPLES_PER_CHUNK = 1024
-# See the note where this is passed to the server.
-_TEST_WORKSPACE_MB = 512
 # Generous: covers a cold TensorRT engine build before the port opens.
 _STARTUP_TIMEOUT = 600
 _TRANSCRIBE_TIMEOUT = 120
@@ -208,19 +206,6 @@ async def test_wyoming_whisper_trt(compute_type: str, decoder_mode: str) -> None
         decoder_mode,
         "--language",
         "en",
-        # Pinned rather than auto-sized, for two reasons.
-        #
-        # auto_workspace_mb derives the budget from free VRAM *at that moment*,
-        # and get_model_filename keys the engine cache on the budget. So when
-        # VRAM is tight the chosen budget differs, the cached engine no longer
-        # matches by name, and the run is forced into exactly the rebuild that
-        # needs the memory it has not got. Pinning it makes the cache hit.
-        #
-        # And these tests prove transcription is correct, not that tactic
-        # search had a generous budget; 512 MiB builds the same engine with
-        # less search, and leaves that much more room for the build itself.
-        "--max-workspace-mb",
-        str(_TEST_WORKSPACE_MB),
         stdin=DEVNULL,
         stdout=PIPE,
         stderr=PIPE,

--- a/whisper_trt/model.py
+++ b/whisper_trt/model.py
@@ -1008,6 +1008,16 @@ def auto_workspace_mb(model_name: str) -> int:
         return target
     spare_mb = free_bytes / (1 << 20) - _BUILD_MEMORY_RESERVE_MB
     cap_mb = int(_WORKSPACE_VRAM_FRACTION * spare_mb)
+    # Round the cap down to a whole number of _MIN_WORKSPACE_MB before it can
+    # reach the caller, because this value ends up in the engine cache
+    # filename (get_model_filename keys on it). Unrounded it tracks free VRAM
+    # continuously -- 3800 MiB free gives ws876, 3500 gives ws726 -- so two
+    # runs of the same build on the same machine disagree about the filename,
+    # the cache misses, and the run is forced into exactly the rebuild that
+    # needs the memory it is short of. Rounding down never asks for more than
+    # the clamp allows, and it takes a swing of a whole bucket to change the
+    # name.
+    cap_mb -= cap_mb % _MIN_WORKSPACE_MB
     return max(_MIN_WORKSPACE_MB, min(target, cap_mb))
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Automatic engine workspace sizing now uses stable, whole-size increments, producing more consistent engine cache behavior across runs.
  - Workspace allocation respects available VRAM limits while enforcing the minimum supported workspace size.
  - End-to-end engine builds now use automatic workspace sizing by default rather than a fixed test value.

- **Tests**
  - Added coverage for workspace stability, rounding behavior, VRAM limits, and minimum-size handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->